### PR TITLE
fix(cargo.toml): use anton-rs repo for kona dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4680,7 +4680,7 @@ dependencies = [
 [[package]]
 name = "kona-client"
 version = "0.1.0"
-source = "git+https://github.com/ethereum-optimism/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
+source = "git+https://github.com/anton-rs/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
 dependencies = [
  "alloy-consensus 0.8.1",
  "alloy-eips 0.8.1",
@@ -4713,7 +4713,7 @@ dependencies = [
 [[package]]
 name = "kona-derive"
 version = "0.2.0"
-source = "git+https://github.com/ethereum-optimism/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
+source = "git+https://github.com/anton-rs/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
 dependencies = [
  "alloy-consensus 0.8.1",
  "alloy-eips 0.8.1",
@@ -4732,7 +4732,7 @@ dependencies = [
 [[package]]
 name = "kona-driver"
 version = "0.2.0"
-source = "git+https://github.com/ethereum-optimism/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
+source = "git+https://github.com/anton-rs/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
 dependencies = [
  "alloy-consensus 0.8.1",
  "alloy-primitives",
@@ -4750,7 +4750,7 @@ dependencies = [
 [[package]]
 name = "kona-executor"
 version = "0.2.0"
-source = "git+https://github.com/ethereum-optimism/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
+source = "git+https://github.com/anton-rs/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
 dependencies = [
  "alloy-consensus 0.8.1",
  "alloy-eips 0.8.1",
@@ -4768,7 +4768,7 @@ dependencies = [
 [[package]]
 name = "kona-host"
 version = "0.1.0"
-source = "git+https://github.com/ethereum-optimism/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
+source = "git+https://github.com/anton-rs/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
 dependencies = [
  "alloy-consensus 0.8.1",
  "alloy-eips 0.8.1",
@@ -4805,7 +4805,7 @@ dependencies = [
 [[package]]
 name = "kona-mpt"
 version = "0.1.1"
-source = "git+https://github.com/ethereum-optimism/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
+source = "git+https://github.com/anton-rs/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4817,7 +4817,7 @@ dependencies = [
 [[package]]
 name = "kona-preimage"
 version = "0.2.0"
-source = "git+https://github.com/ethereum-optimism/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
+source = "git+https://github.com/anton-rs/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
 dependencies = [
  "alloy-primitives",
  "async-channel",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "kona-proof"
 version = "0.2.0"
-source = "git+https://github.com/ethereum-optimism/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
+source = "git+https://github.com/anton-rs/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
 dependencies = [
  "alloy-consensus 0.8.1",
  "alloy-eips 0.8.1",
@@ -4860,7 +4860,7 @@ dependencies = [
 [[package]]
 name = "kona-std-fpvm"
 version = "0.1.1"
-source = "git+https://github.com/ethereum-optimism/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
+source = "git+https://github.com/anton-rs/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -4872,7 +4872,7 @@ dependencies = [
 [[package]]
 name = "kona-std-fpvm-proc"
 version = "0.1.1"
-source = "git+https://github.com/ethereum-optimism/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
+source = "git+https://github.com/anton-rs/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,15 +63,15 @@ kailua-contracts = { path = "crates/contracts" }
 kailua-host = { path = "bin/host" }
 
 # Kona
-kona-client = { git = "https://github.com/ethereum-optimism/kona", rev = "7a40d87", default-features = false }
-kona-derive = { git = "https://github.com/ethereum-optimism/kona", rev = "7a40d87", default-features = false, features = ["serde"] }
-kona-driver = { git = "https://github.com/ethereum-optimism/kona", rev = "7a40d87" }
-kona-executor = { git = "https://github.com/ethereum-optimism/kona", rev = "7a40d87" }
-kona-host = { git = "https://github.com/ethereum-optimism/kona", rev = "7a40d87" }
-kona-mpt = { git = "https://github.com/ethereum-optimism/kona", rev = "7a40d87", features = ["serde"] }
-kona-preimage = { git = "https://github.com/ethereum-optimism/kona", rev = "7a40d87", features = ["rkyv"] }
-kona-proof = { git = "https://github.com/ethereum-optimism/kona", rev = "7a40d87" }
-kona-std-fpvm = { git = "https://github.com/ethereum-optimism/kona", rev = "7a40d87" }
+kona-client = { git = "https://github.com/anton-rs/kona", rev = "7a40d87", default-features = false }
+kona-derive = { git = "https://github.com/anton-rs/kona", rev = "7a40d87", default-features = false, features = ["serde"] }
+kona-driver = { git = "https://github.com/anton-rs/kona", rev = "7a40d87" }
+kona-executor = { git = "https://github.com/anton-rs/kona", rev = "7a40d87" }
+kona-host = { git = "https://github.com/anton-rs/kona", rev = "7a40d87" }
+kona-mpt = { git = "https://github.com/anton-rs/kona", rev = "7a40d87", features = ["serde"] }
+kona-preimage = { git = "https://github.com/anton-rs/kona", rev = "7a40d87", features = ["rkyv"] }
+kona-proof = { git = "https://github.com/anton-rs/kona", rev = "7a40d87" }
+kona-std-fpvm = { git = "https://github.com/anton-rs/kona", rev = "7a40d87" }
 
 # RISC Zero zkVM
 bonsai-sdk = { version = "1.2.0", features = ["non_blocking"] }

--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ We'd love to hear from you on [Discord][discord] or [Twitter][twitter].
 [twitter]: https://twitter.com/risczero
 [zkvm-overview]: https://dev.risczero.com/zkvm
 [zkhack-iii]: https://www.youtube.com/watch?v=Yg_BGqj_6lg&list=PLcPzhUaCxlCgig7ofeARMPwQ8vbuD6hC5&index=5
-[kona]: https://github.com/ethereum-optimism/kona
+[kona]: https://github.com/anton-rs/kona

--- a/build/risczero/fpvm/Cargo.lock
+++ b/build/risczero/fpvm/Cargo.lock
@@ -1634,7 +1634,7 @@ dependencies = [
 [[package]]
 name = "kona-derive"
 version = "0.2.0"
-source = "git+https://github.com/ethereum-optimism/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
+source = "git+https://github.com/anton-rs/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -1653,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "kona-driver"
 version = "0.2.0"
-source = "git+https://github.com/ethereum-optimism/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
+source = "git+https://github.com/anton-rs/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -1671,7 +1671,7 @@ dependencies = [
 [[package]]
 name = "kona-executor"
 version = "0.2.0"
-source = "git+https://github.com/ethereum-optimism/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
+source = "git+https://github.com/anton-rs/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -1689,7 +1689,7 @@ dependencies = [
 [[package]]
 name = "kona-mpt"
 version = "0.1.1"
-source = "git+https://github.com/ethereum-optimism/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
+source = "git+https://github.com/anton-rs/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -1701,7 +1701,7 @@ dependencies = [
 [[package]]
 name = "kona-preimage"
 version = "0.2.0"
-source = "git+https://github.com/ethereum-optimism/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
+source = "git+https://github.com/anton-rs/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -1714,7 +1714,7 @@ dependencies = [
 [[package]]
 name = "kona-proof"
 version = "0.2.0"
-source = "git+https://github.com/ethereum-optimism/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
+source = "git+https://github.com/anton-rs/kona?rev=7a40d87#7a40d87b616556f76fc49f1651e035b975a2ed1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/build/risczero/fpvm/Cargo.toml
+++ b/build/risczero/fpvm/Cargo.toml
@@ -12,7 +12,7 @@ rkyv = "0.8.9"
 
 kailua-common = { path = "../../../crates/common" }
 
-kona-proof = { git = "https://github.com/ethereum-optimism/kona", rev = "7a40d87" }
+kona-proof = { git = "https://github.com/anton-rs/kona", rev = "7a40d87" }
 
 risc0-zkvm = { version = "1.2.0", features = ["std", "heap-embedded-alloc", "unstable"] }
 


### PR DESCRIPTION
https://github.com/ethereum-optimism/kona symlinks to https://github.com/anton-rs/kona, but it seems like Cargo doesn't understands this, because when importing our eigenda crate that points to the anton-rs repo, was hitting this bug:
```
cargo tree -i kona-proof     
error: There are multiple `kona-proof` packages in your project, and the specification `kona-proof` is ambiguous.
Please re-run this command with one of the following specifications:
  git+https://github.com/anton-rs/kona?rev=7a40d87#kona-proof@0.2.0
  git+https://github.com/ethereum-optimism/kona?rev=7a40d87#kona-proof@0.2.0
```
So changed all references to ethereum-optimism to point to the real anton-rs repo.