### PR TITLE
typo-Update config.rs

### DIFF
--- a/bin/cli/src/config.rs
+++ b/bin/cli/src/config.rs
@@ -90,7 +90,7 @@ pub async fn config(args: ConfigArgs) -> anyhow::Result<()> {
         11155420 => Some(address!("B369b4dd27FBfb59921d3A4a3D23AC2fc32FB908")),
         // linea
         59144 => Some(address!("0b144e07a0826182b6b59788c34b32bfa86fb711")),
-        // ploygon
+        // polygon
         1101 => Some(address!("0b144e07a0826182b6b59788c34b32bfa86fb711")),
         _ => None,
     };


### PR DESCRIPTION
# Fix: Corrected typo in source file

## Changes
1. **File**: `bin/cli/src/config.rs`
   - Fixed a typo by changing "ploygon" to "polygon" (Line 93).

## Purpose
- Improved code accuracy by fixing the typographical error.
- Enhanced the clarity and professionalism of the codebase.
