### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ We'd love to hear from you on [Discord][discord] or [Twitter][twitter].
 [risc0-zkvm]: https://docs.rs/risc0-zkvm
 [rustup]: https://rustup.rs
 [rust-toolchain]: rust-toolchain.toml
-[twitter]: https://twitter.com/risczero
+[twitter]: https://x.com/risczero
 [zkvm-overview]: https://dev.risczero.com/zkvm
 [zkhack-iii]: https://www.youtube.com/watch?v=Yg_BGqj_6lg&list=PLcPzhUaCxlCgig7ofeARMPwQ8vbuD6hC5&index=5
 [kona]: https://github.com/anton-rs/kona

--- a/crates/contracts/foundry/lib/forge-std/src/safeconsole.sol
+++ b/crates/contracts/foundry/lib/forge-std/src/safeconsole.sol
@@ -6,7 +6,7 @@ pragma solidity >=0.6.2 <0.9.0;
 library safeconsole {
     uint256 constant CONSOLE_ADDR = 0x000000000000000000000000000000000000000000636F6e736F6c652e6c6f67;
 
-    // Credit to [0age](https://twitter.com/z0age/status/1654922202930888704) and [0xdapper](https://github.com/foundry-rs/forge-std/pull/374)
+    // Credit to [0age](https://x.com/z0age/status/1654922202930888704) and [0xdapper](https://github.com/foundry-rs/forge-std/pull/374)
     // for the view-to-pure log trick.
     function _sendLogPayload(uint256 offset, uint256 size) private pure {
         function(uint256, uint256) internal view fnIn = _sendLogPayloadView;


### PR DESCRIPTION
Replaced the outdated Twitter URL (https://twitter.com) with the updated x.com format (https://x.com) to align with the platform's rebranding.