### PR TITLE
feat: Parallel Proving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5247,6 +5247,7 @@ dependencies = [
  "alloy-eips 0.11.1",
  "alloy-primitives",
  "anyhow",
+ "async-channel",
  "bincode",
  "bonsai-sdk",
  "bytemuck",

--- a/bin/cli/src/channel.rs
+++ b/bin/cli/src/channel.rs
@@ -14,8 +14,6 @@
 
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
-pub type AsyncChannel<T> = (async_channel::Sender<T>, async_channel::Receiver<T>);
-
 /// A channel for two-way communication
 #[derive(Debug)]
 pub struct DuplexChannel<T> {

--- a/bin/cli/src/validate/mod.rs
+++ b/bin/cli/src/validate/mod.rs
@@ -72,7 +72,7 @@ pub struct ValidateArgs {
     pub fast_forward_target: u64,
     /// How many proofs to compute simultaneously
     #[clap(long, env, default_value_t = 1)]
-    pub num_concurrent_proofs: u64,
+    pub num_concurrent_hosts: u64,
 
     /// Secret key of L1 wallet to use for challenging and proving outputs
     #[clap(flatten)]
@@ -1090,7 +1090,7 @@ pub async fn handle_proof_requests(
     let task_channel: AsyncChannel<Task> = async_channel::unbounded();
     let mut proving_handlers = vec![];
     // instantiate worker pool
-    for _ in 0..args.num_concurrent_proofs {
+    for _ in 0..args.num_concurrent_hosts {
         proving_handlers.push(spawn(handle_proving_tasks(
             args.kailua_host.clone(),
             task_channel.clone(),

--- a/bin/client/src/proving.rs
+++ b/bin/client/src/proving.rs
@@ -57,7 +57,7 @@ impl ProvingArgs {
     }
 }
 
-#[derive(thiserror::Error, Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ProvingError {
     #[error("DerivationProofError error: execution proofs {0}")]
     DerivationProofError(usize),

--- a/bin/host/Cargo.toml
+++ b/bin/host/Cargo.toml
@@ -12,6 +12,7 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+async-channel.workspace = true
 bincode.workspace = true
 bytemuck.workspace = true
 clap.workspace = true

--- a/bin/host/src/args.rs
+++ b/bin/host/src/args.rs
@@ -34,6 +34,9 @@ pub struct KailuaHostArgs {
     /// How many threads to use for fetching preflight data
     #[clap(long, env, default_value_t = 4)]
     pub num_preflight_threads: u64,
+    /// How many threads to use for computing proofs
+    #[clap(long, env, default_value_t = 1)]
+    pub num_proving_threads: u64,
 
     #[clap(flatten)]
     pub proving: ProvingArgs,

--- a/bin/host/src/args.rs
+++ b/bin/host/src/args.rs
@@ -33,10 +33,10 @@ pub struct KailuaHostArgs {
     pub skip_zeth_preflight: bool,
     /// How many threads to use for fetching preflight data
     #[clap(long, env, default_value_t = 4)]
-    pub num_preflight_threads: u64,
+    pub num_concurrent_preflights: u64,
     /// How many threads to use for computing proofs
     #[clap(long, env, default_value_t = 1)]
-    pub num_proving_threads: u64,
+    pub num_concurrent_proofs: u64,
 
     #[clap(flatten)]
     pub proving: ProvingArgs,

--- a/bin/host/src/channel.rs
+++ b/bin/host/src/channel.rs
@@ -1,4 +1,4 @@
-// Copyright 2024, 2025 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,11 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod args;
-pub mod channel;
-pub mod config;
-pub mod kv;
-pub mod preflight;
-pub mod prove;
-pub mod server;
-pub mod tasks;
+pub type AsyncChannel<T> = (async_channel::Sender<T>, async_channel::Receiver<T>);

--- a/bin/host/src/main.rs
+++ b/bin/host/src/main.rs
@@ -28,7 +28,7 @@ use kailua_host::preflight::{
     concurrent_execution_preflight, fetch_precondition_data, zeth_execution_preflight,
 };
 use kailua_host::server::create_disk_kv_store;
-use kailua_host::tasks::{handle_oneshot_tasks, Oneshot};
+use kailua_host::tasks::{handle_oneshot_tasks, Cached, Oneshot, OneshotResult};
 use std::collections::BinaryHeap;
 use std::env::set_var;
 use tempfile::tempdir;
@@ -111,52 +111,105 @@ async fn main() -> anyhow::Result<()> {
         proving_handlers.push(tokio::spawn(handle_oneshot_tasks(task_channel.1.clone())));
     }
 
-    // compute individual proofs
-    let mut job_pq = BinaryHeap::new();
-    let mut proofs = Vec::new();
-    job_pq.push(args.clone());
-    let mut have_split = false;
-    while let Some(job_args) = job_pq.pop() {
-        let starting_block = if let Some(l2_provider) = l2_provider.as_ref() {
-            l2_provider
-                .get_block_by_hash(
-                    job_args.kona.agreed_l2_head_hash,
-                    BlockTransactionsKind::Hashes,
-                )
-                .await?
-                .unwrap()
-                .header
-                .number
-        } else {
-            0
-        };
-
-        let num_blocks = job_args.kona.claimed_l2_block_number - starting_block;
-        if starting_block > 0 {
-            info!(
-                "Processing job with {} blocks from block {}",
-                num_blocks, starting_block
-            );
-        }
-        // Force the proving attempt regardless of witness size if we prove just one block
-        let force_attempt = num_blocks == 1 || job_args.kona.is_offline();
-
-        match kailua_host::prove::compute_fpvm_proof(
-            job_args.clone(),
-            rollup_config.clone(),
-            disk_kv_store.clone(),
-            precondition_hash,
-            precondition_validation_data_hash,
-            vec![],
-            vec![],
-            !have_split,
-            task_channel.0.clone(),
-        )
+    // create proofs channel
+    let result_channel = async_channel::unbounded();
+    let prover_channel = async_channel::unbounded();
+    let mut result_pq = BinaryHeap::new();
+    let mut num_proofs = 1;
+    prover_channel
+        .0
+        .send((false, args.clone()))
         .await
-        {
+        .expect("Failed to send prover task");
+    while result_pq.len() < num_proofs {
+        // dispatch all pending proofs
+        while !prover_channel.1.is_empty() {
+            let (have_split, job_args) = prover_channel
+                .1
+                .recv()
+                .await
+                .expect("Failed to recv prover task");
+            let starting_block = if let Some(l2_provider) = l2_provider.as_ref() {
+                l2_provider
+                    .get_block_by_hash(
+                        job_args.kona.agreed_l2_head_hash,
+                        BlockTransactionsKind::Hashes,
+                    )
+                    .await?
+                    .unwrap()
+                    .header
+                    .number
+            } else {
+                0
+            };
+
+            let num_blocks = job_args.kona.claimed_l2_block_number - starting_block;
+            if starting_block > 0 {
+                info!(
+                    "Processing job with {} blocks from block {}",
+                    num_blocks, starting_block
+                );
+            }
+            // Force the proving attempt regardless of witness size if we prove just one block
+            let force_attempt = num_blocks == 1 || job_args.kona.is_offline();
+
+            // spawn a job that computes the proof and sends back the result to result_channel
+            let rollup_config = rollup_config.clone();
+            let disk_kv_store = disk_kv_store.clone();
+            let task_channel = task_channel.clone();
+            let result_channel = result_channel.clone();
+            tokio::spawn(async move {
+                let result = kailua_host::prove::compute_fpvm_proof(
+                    job_args.clone(),
+                    rollup_config,
+                    disk_kv_store,
+                    precondition_hash,
+                    precondition_validation_data_hash,
+                    vec![],
+                    vec![],
+                    !have_split,
+                    task_channel.0.clone(),
+                )
+                .await;
+
+                result_channel
+                    .0
+                    .clone()
+                    .send((starting_block, job_args, force_attempt, result))
+                    .await
+                    .expect("Failed to send fpvm proof result");
+            });
+        }
+
+        // receive and process new results
+        let (starting_block, job_args, force_attempt, result) = result_channel
+            .1
+            .recv()
+            .await
+            .expect("Failed to recv prover task");
+        let num_blocks = job_args.kona.claimed_l2_block_number - starting_block;
+
+        match result {
             Ok(proof) => {
                 if let Some(proof) = proof {
-                    proofs.push(proof);
+                    result_pq.push(OneshotResult {
+                        cached: Cached {
+                            // used for sorting
+                            args: job_args,
+                            // all unused
+                            rollup_config: rollup_config.clone(),
+                            disk_kv_store: disk_kv_store.clone(),
+                            precondition_hash,
+                            precondition_validation_data_hash,
+                            stitched_executions: vec![],
+                            stitched_boot_info: vec![],
+                            stitched_proofs: vec![],
+                            prove_snark: false,
+                            force_attempt,
+                            seek_proof: true,
+                        },
+                        result: Ok(proof),
+                    });
                 }
             }
             Err(err) => {
@@ -166,7 +219,7 @@ async fn main() -> anyhow::Result<()> {
                         if force_attempt {
                             bail!(
                                 "Received WitnessSizeError({f},{t}) for a forced proving attempt: {err:?}"
-                            );
+                                );
                         }
                         warn!("Proof witness size {f} above safety threshold {t}. Splitting workload.")
                     }
@@ -179,14 +232,17 @@ async fn main() -> anyhow::Result<()> {
                     ProvingError::OtherError(e) => {
                         bail!("Irrecoverable proving error: {e:?}")
                     }
-                    ProvingError::SeekProofError(..) => unreachable!("SeekProofError bubbled up"),
+                    ProvingError::SeekProofError(..) => {
+                        unreachable!("SeekProofError bubbled up")
+                    }
                     ProvingError::DerivationProofError(proofs) => {
                         info!("Computed {proofs} execution-only proofs.");
                         continue;
                     }
                 }
+                // Require additional proof
+                num_proofs += 1;
                 // Split workload at midpoint (num_blocks > 1)
-                have_split = true;
                 let mid_point = starting_block + num_blocks / 2;
                 let mid_output = op_node_provider
                     .as_ref()
@@ -206,15 +262,29 @@ async fn main() -> anyhow::Result<()> {
                 let mut lower_job_args = job_args.clone();
                 lower_job_args.kona.claimed_l2_output_root = mid_output;
                 lower_job_args.kona.claimed_l2_block_number = mid_point;
-                job_pq.push(lower_job_args);
+                prover_channel
+                    .0
+                    .send((true, lower_job_args))
+                    .await
+                    .expect("Failed to send prover task");
                 // upper half workload starts after midpoint
                 let mut upper_job_args = job_args;
                 upper_job_args.kona.agreed_l2_output_root = mid_output;
                 upper_job_args.kona.agreed_l2_head_hash = mid_block.header.hash;
-                job_pq.push(upper_job_args);
+                prover_channel
+                    .0
+                    .send((true, upper_job_args))
+                    .await
+                    .expect("Failed to send prover task");
             }
         }
     }
+    // gather sorted proofs into vec
+    let proofs = result_pq
+        .into_iter()
+        .map(|r| r.result.expect("Failed to get result"))
+        .collect::<Vec<_>>();
+
     // stitch contiguous proofs together
     if proofs.len() > 1 {
         info!("Composing {} proofs together.", proofs.len());

--- a/bin/host/src/main.rs
+++ b/bin/host/src/main.rs
@@ -281,7 +281,9 @@ async fn main() -> anyhow::Result<()> {
     }
     // gather sorted proofs into vec
     let proofs = result_pq
+        .into_sorted_vec()
         .into_iter()
+        .rev()
         .map(|r| r.result.expect("Failed to get result"))
         .collect::<Vec<_>>();
 
@@ -312,6 +314,7 @@ async fn main() -> anyhow::Result<()> {
             .iter()
             .map(StitchedBootInfo::from)
             .collect::<Vec<_>>();
+
         kailua_host::prove::compute_fpvm_proof(
             base_args,
             rollup_config.clone(),

--- a/bin/host/src/main.rs
+++ b/bin/host/src/main.rs
@@ -83,11 +83,11 @@ async fn main() -> anyhow::Result<()> {
     // create concurrent db
     let disk_kv_store = create_disk_kv_store(&args.kona);
     // perform preflight to fetch data
-    if args.num_preflight_threads > 1 {
+    if args.num_concurrent_preflights > 1 {
         // run parallelized preflight instances to populate kv store
         info!(
             "Running concurrent preflights with {} threads",
-            args.num_preflight_threads
+            args.num_concurrent_preflights
         );
         concurrent_execution_preflight(
             &args,
@@ -107,7 +107,7 @@ async fn main() -> anyhow::Result<()> {
     // spin up proving workers
     let task_channel: AsyncChannel<Oneshot> = async_channel::unbounded();
     let mut proving_handlers = vec![];
-    for _ in 0..args.num_proving_threads {
+    for _ in 0..args.num_concurrent_proofs {
         proving_handlers.push(tokio::spawn(handle_oneshot_tasks(task_channel.1.clone())));
     }
 

--- a/bin/host/src/preflight.rs
+++ b/bin/host/src/preflight.rs
@@ -269,8 +269,8 @@ pub async fn concurrent_execution_preflight(
     if num_blocks == 0 {
         return Ok(());
     }
-    let blocks_per_thread = num_blocks / args.num_preflight_threads;
-    let mut extra_blocks = num_blocks % args.num_preflight_threads;
+    let blocks_per_thread = num_blocks / args.num_concurrent_preflights;
+    let mut extra_blocks = num_blocks % args.num_concurrent_preflights;
     let mut jobs = vec![];
     let mut args = args.clone();
     while num_blocks > 0 {

--- a/bin/host/src/preflight.rs
+++ b/bin/host/src/preflight.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::args::KailuaHostArgs;
-use crate::server::create_disk_kv_store;
+use crate::kv::RWLKeyValueStore;
 use alloy::consensus::Transaction;
 use alloy::network::primitives::BlockTransactionsKind;
 use alloy::providers::{Provider, RootProvider};
@@ -23,6 +23,7 @@ use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{keccak256, B256};
 use anyhow::bail;
 use kailua_client::provider::OpNodeProvider;
+use kailua_client::proving::ProvingError;
 use kailua_common::blobs::BlobFetchRequest;
 use kailua_common::precondition::PreconditionValidationData;
 use kona_genesis::RollupConfig;
@@ -255,6 +256,7 @@ pub async fn concurrent_execution_preflight(
     args: &KailuaHostArgs,
     rollup_config: RollupConfig,
     op_node_provider: &OpNodeProvider,
+    disk_kv_store: Option<RWLKeyValueStore>,
 ) -> anyhow::Result<()> {
     let l2_provider = args.kona.create_providers().await?.l2;
     let starting_block = l2_provider
@@ -271,7 +273,6 @@ pub async fn concurrent_execution_preflight(
     let mut extra_blocks = num_blocks % args.num_preflight_threads;
     let mut jobs = vec![];
     let mut args = args.clone();
-    let disk_kv_store = create_disk_kv_store(&args.kona);
     while num_blocks > 0 {
         let processed_blocks = if extra_blocks > 0 {
             extra_blocks -= 1;
@@ -325,7 +326,9 @@ pub async fn concurrent_execution_preflight(
     for job in jobs {
         let result = job.await?;
         if let Err(e) = result {
-            error!("Error during preflight execution: {e:?}");
+            if !matches!(e, ProvingError::SeekProofError(..)) {
+                error!("Error during preflight execution: {e:?}");
+            }
         }
     }
 

--- a/bin/host/src/prove.rs
+++ b/bin/host/src/prove.rs
@@ -14,11 +14,14 @@
 
 use crate::args::KailuaHostArgs;
 use crate::kv::RWLKeyValueStore;
+use crate::tasks;
+use crate::tasks::{Cached, Oneshot};
 use alloy::network::primitives::BlockTransactionsKind;
 use alloy::providers::Provider;
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::B256;
 use anyhow::{anyhow, Context};
+use async_channel::Sender;
 use kailua_build::KAILUA_FPVM_ID;
 use kailua_client::proof::{proof_file_name, read_proof_file};
 use kailua_client::proving::ProvingError;
@@ -30,6 +33,7 @@ use kona_genesis::RollupConfig;
 use kona_proof::BootInfo;
 use std::collections::BinaryHeap;
 use std::path::Path;
+use std::sync::Arc;
 use tracing::{info, warn};
 
 /// Computes a receipt if it is not cached
@@ -43,6 +47,7 @@ pub async fn compute_fpvm_proof(
     stitched_boot_info: Vec<StitchedBootInfo>,
     stitched_proofs: Vec<Proof>,
     prove_snark: bool,
+    task_sender: Sender<Oneshot>,
 ) -> Result<Option<Proof>, ProvingError> {
     // report transaction count
     if !stitched_boot_info.is_empty() {
@@ -91,7 +96,7 @@ pub async fn compute_fpvm_proof(
     let stitching_only = args.kona.agreed_l2_output_root == args.kona.claimed_l2_output_root;
     // generate master proof
     info!("Attempting complete proof.");
-    let complete_proof_result = compute_cached_proof(
+    let complete_proof_result = tasks::compute_oneshot_task(
         args.clone(),
         rollup_config.clone(),
         disk_kv_store.clone(),
@@ -100,9 +105,13 @@ pub async fn compute_fpvm_proof(
         vec![],
         stitched_boot_info.clone(),
         stitched_proofs.clone(),
-        prove_snark,                         // pass through snark requirement
-        stitching_only, // force attempting to compute the proof if it only combines boot infos
-        !args.proving.skip_derivation_proof, // skip seeking a complete proof if skipping derivation
+        // pass through snark requirement
+        prove_snark,
+        // force attempting to compute the proof if it only combines boot infos
+        stitching_only,
+        // skip seeking a complete proof if skipping derivation
+        !args.proving.skip_derivation_proof,
+        task_sender.clone(),
     )
     .await;
     // on WitnessSizeError or SeekProofError, extract execution trace
@@ -120,7 +129,7 @@ pub async fn compute_fpvm_proof(
             "Performing derivation-only run for {} executions.",
             execution_cache.len()
         );
-        let derivation_only_result = compute_cached_proof(
+        let derivation_only_result = tasks::compute_oneshot_task(
             args.clone(),
             rollup_config.clone(),
             disk_kv_store.clone(),
@@ -132,6 +141,7 @@ pub async fn compute_fpvm_proof(
             false,
             true,
             false,
+            task_sender.clone(),
         )
         .await;
         // propagate unexpected error up on failure to trigger higher-level division
@@ -144,116 +154,125 @@ pub async fn compute_fpvm_proof(
         };
     }
 
-    // compute execution proofs
-    let mut job_pq = BinaryHeap::new();
-    let mut proofs = Vec::new();
+    // create proofs channel
+    let result_channel = async_channel::unbounded();
+    let mut result_pq = BinaryHeap::new();
     // start with full execution proof
-    job_pq.push({
-        let mut args = args.clone();
-        args.kona.l1_head = B256::ZERO;
-        args
-    });
-    // divide and conquer executions
-    let mut stitched_executions = vec![];
-    while let Some(job_args) = job_pq.pop() {
-        let starting_block = execution_cache
-            .iter()
-            .find(|e| e.agreed_output == job_args.kona.agreed_l2_output_root)
-            .expect("Failed to find the first execution.")
-            .artifacts
-            .block_header
-            .number
-            - 1;
-        let num_blocks = job_args.kona.claimed_l2_block_number - starting_block;
-        info!(
-            "Processing execution-only job with {} blocks from block {}",
-            num_blocks, starting_block
-        );
-        // Extract executed slice
-        let executed_blocks = execution_cache
-            .iter()
-            .filter(|e| {
-                let executed_block_number = e.artifacts.block_header.number;
-
-                starting_block < executed_block_number
-                    && executed_block_number <= job_args.kona.claimed_l2_block_number
-            })
-            .cloned()
-            .collect::<Vec<_>>();
-        let precondition_hash = exec_precondition_hash(executed_blocks.as_slice());
-
-        // Force the proving attempt regardless of witness size if we prove just one block
-        let force_attempt = num_blocks == 1;
-        let executed_blocks = executed_blocks
-            .iter()
-            .map(|a| a.as_ref().clone())
-            .collect::<Vec<_>>();
-        match compute_cached_proof(
-            job_args.clone(),
-            rollup_config.clone(),
-            disk_kv_store.clone(),
-            precondition_hash,
-            B256::ZERO,
-            vec![executed_blocks.clone()],
-            vec![],
-            vec![],
-            false,
-            force_attempt,
-            true,
-        )
+    task_sender
+        .send(Oneshot {
+            cached_task: create_cached_execution_task(
+                {
+                    let mut args = args.clone();
+                    args.kona.l1_head = B256::ZERO;
+                    args
+                },
+                rollup_config.clone(),
+                disk_kv_store.clone(),
+                &execution_cache,
+            ),
+            result_sender: result_channel.0.clone(),
+        })
         .await
-        {
-            Ok(proof) => {
-                // conquered
-                proofs.push(proof);
-                stitched_executions.push(executed_blocks);
-            }
-            Err(err) => {
-                // divide or bail out on error
-                match err {
-                    ProvingError::WitnessSizeError(f, t, e) => {
-                        if force_attempt {
-                            return Err(ProvingError::WitnessSizeError(f, t, e));
-                        }
-                        warn!("Proof witness size {f} above safety threshold {t}. Splitting workload.")
-                    }
-                    ProvingError::ExecutionError(e) => {
-                        if force_attempt {
-                            return Err(ProvingError::ExecutionError(e));
-                        }
-                        warn!("Splitting proof after ZKVM execution error: {e:?}")
-                    }
-                    ProvingError::OtherError(e) => {
-                        return Err(ProvingError::OtherError(e));
-                    }
-                    ProvingError::SeekProofError(_, _) => {
-                        unreachable!("Sought proof, found SeekProofError {err:?}")
-                    }
-                    ProvingError::DerivationProofError(_) => {
-                        unreachable!("Sought proof, found DerivationProofError {err:?}")
-                    }
+        .expect("task_channel should not be closed");
+    // divide and conquer executions
+    let mut num_proofs = 1;
+    loop {
+        // Break if we've received all proofs
+        if result_pq.len() == num_proofs {
+            break;
+        }
+        // Wait for more proving results
+        let oneshot_result = result_channel
+            .1
+            .recv()
+            .await
+            .expect("result_channel should not be closed");
+        let Err(err) = oneshot_result.result else {
+            result_pq.push(oneshot_result);
+            continue;
+        };
+        // Require additional proof
+        num_proofs += 1;
+        let executed_blocks = oneshot_result.cached.stitched_executions[0].clone();
+        let starting_block = executed_blocks[0].artifacts.block_header.number - 1;
+        let num_blocks = oneshot_result.cached.args.kona.claimed_l2_block_number - starting_block;
+        let force_attempt = num_blocks == 1;
+        // divide or bail out on error
+        match err {
+            ProvingError::WitnessSizeError(f, t, e) => {
+                if force_attempt {
+                    return Err(ProvingError::WitnessSizeError(f, t, e));
                 }
-                // Split workload at midpoint (num_blocks > 1)
-                let mid_point = starting_block + num_blocks / 2;
-                let mid_exec = executed_blocks
-                    .iter()
-                    .find(|e| e.artifacts.block_header.number == mid_point)
-                    .expect("Failed to find the midpoint of execution.");
-                let mid_output = mid_exec.claimed_output;
-                // Lower half workload ends at midpoint (inclusive)
-                let mut lower_job_args = job_args.clone();
-                lower_job_args.kona.claimed_l2_output_root = mid_output;
-                lower_job_args.kona.claimed_l2_block_number = mid_point;
-                job_pq.push(lower_job_args);
-                // upper half workload starts after midpoint
-                let mut upper_job_args = job_args;
-                upper_job_args.kona.agreed_l2_output_root = mid_output;
-                upper_job_args.kona.agreed_l2_head_hash = mid_exec.artifacts.block_header.hash();
-                job_pq.push(upper_job_args);
+                warn!("Proof witness size {f} above safety threshold {t}. Splitting workload.")
+            }
+            ProvingError::ExecutionError(e) => {
+                if force_attempt {
+                    return Err(ProvingError::ExecutionError(e));
+                }
+                warn!("Splitting proof after ZKVM execution error: {e:?}")
+            }
+            ProvingError::OtherError(e) => {
+                return Err(ProvingError::OtherError(e));
+            }
+            ProvingError::SeekProofError(_, _) => {
+                unreachable!("Sought proof, found SeekProofError {err:?}")
+            }
+            ProvingError::DerivationProofError(_) => {
+                unreachable!("Sought proof, found DerivationProofError {err:?}")
             }
         }
+        // Split workload at midpoint (num_blocks > 1)
+        let mid_point = starting_block + num_blocks / 2;
+        let mid_exec = executed_blocks
+            .iter()
+            .find(|e| e.artifacts.block_header.number == mid_point)
+            .expect("Failed to find the midpoint of execution.");
+        let mid_output = mid_exec.claimed_output;
+
+        // Lower half workload ends at midpoint (inclusive)
+        let mut lower_job_args = oneshot_result.cached.args.clone();
+        lower_job_args.kona.claimed_l2_output_root = mid_output;
+        lower_job_args.kona.claimed_l2_block_number = mid_point;
+        task_sender
+            .send(Oneshot {
+                cached_task: create_cached_execution_task(
+                    lower_job_args,
+                    rollup_config.clone(),
+                    disk_kv_store.clone(),
+                    &execution_cache,
+                ),
+                result_sender: result_channel.0.clone(),
+            })
+            .await
+            .expect("task_channel should not be closed");
+
+        // upper half workload starts after midpoint
+        let mut upper_job_args = oneshot_result.cached.args;
+        upper_job_args.kona.agreed_l2_output_root = mid_output;
+        upper_job_args.kona.agreed_l2_head_hash = mid_exec.artifacts.block_header.hash();
+        task_sender
+            .send(Oneshot {
+                cached_task: create_cached_execution_task(
+                    upper_job_args,
+                    rollup_config.clone(),
+                    disk_kv_store.clone(),
+                    &execution_cache,
+                ),
+                result_sender: result_channel.0.clone(),
+            })
+            .await
+            .expect("task_channel should not be closed");
     }
-    stitched_executions.reverse();
+    // Read result_pq for stitched executions and proofs
+    let (proofs, stitched_executions): (Vec<_>, Vec<_>) = result_pq
+        .into_iter()
+        .map(|mut r| {
+            (
+                r.result.expect("pushed failing result to queue"),
+                r.cached.stitched_executions.pop().unwrap(),
+            )
+        })
+        .unzip();
 
     // Return no proof if derivation is not required
     if args.proving.skip_derivation_proof {
@@ -268,7 +287,7 @@ pub async fn compute_fpvm_proof(
         stitched_executions.len()
     );
     Ok(Some(
-        compute_cached_proof(
+        tasks::compute_oneshot_task(
             args,
             rollup_config,
             disk_kv_store,
@@ -280,9 +299,64 @@ pub async fn compute_fpvm_proof(
             prove_snark,
             true,
             true,
+            task_sender.clone(),
         )
         .await?,
     ))
+}
+
+pub fn create_cached_execution_task(
+    args: KailuaHostArgs,
+    rollup_config: RollupConfig,
+    disk_kv_store: Option<RWLKeyValueStore>,
+    execution_cache: &[Arc<Execution>],
+) -> Cached {
+    let starting_block = execution_cache
+        .iter()
+        .find(|e| e.agreed_output == args.kona.agreed_l2_output_root)
+        .expect("Failed to find the first execution.")
+        .artifacts
+        .block_header
+        .number
+        - 1;
+    let num_blocks = args.kona.claimed_l2_block_number - starting_block;
+    info!(
+        "Processing execution-only job with {} blocks from block {}",
+        num_blocks, starting_block
+    );
+    // Extract executed slice
+    let executed_blocks = execution_cache
+        .iter()
+        .filter(|e| {
+            let executed_block_number = e.artifacts.block_header.number;
+
+            starting_block < executed_block_number
+                && executed_block_number <= args.kona.claimed_l2_block_number
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let precondition_hash = exec_precondition_hash(executed_blocks.as_slice());
+
+    // Force the proving attempt regardless of witness size if we prove just one block
+    let force_attempt = num_blocks == 1;
+    let executed_blocks = executed_blocks
+        .iter()
+        .map(|a| a.as_ref().clone())
+        .collect::<Vec<_>>();
+
+    Cached {
+        args,
+        rollup_config,
+        disk_kv_store,
+        precondition_hash,
+        precondition_validation_data_hash: B256::ZERO,
+        stitched_executions: vec![executed_blocks],
+        stitched_boot_info: vec![],
+        stitched_proofs: vec![],
+        prove_snark: false,
+        force_attempt,
+        seek_proof: true,
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/bin/host/src/tasks.rs
+++ b/bin/host/src/tasks.rs
@@ -1,0 +1,183 @@
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::args::KailuaHostArgs;
+use crate::kv::RWLKeyValueStore;
+use crate::prove;
+use alloy_primitives::B256;
+use anyhow::Context;
+use async_channel::{Receiver, Sender};
+use kailua_client::proving::ProvingError;
+use kailua_common::executor::Execution;
+use kailua_common::proof::Proof;
+use kailua_common::witness::StitchedBootInfo;
+use kona_genesis::RollupConfig;
+use std::cmp::Ordering;
+use tracing::error;
+
+#[derive(Clone, Debug)]
+pub struct Cached {
+    pub args: KailuaHostArgs,
+    pub rollup_config: RollupConfig,
+    pub disk_kv_store: Option<RWLKeyValueStore>,
+    pub precondition_hash: B256,
+    pub precondition_validation_data_hash: B256,
+    pub stitched_executions: Vec<Vec<Execution>>,
+    pub stitched_boot_info: Vec<StitchedBootInfo>,
+    pub stitched_proofs: Vec<Proof>,
+    pub prove_snark: bool,
+    pub force_attempt: bool,
+    pub seek_proof: bool,
+}
+
+impl Cached {
+    pub async fn compute(self) -> Result<Proof, ProvingError> {
+        prove::compute_cached_proof(
+            self.args,
+            self.rollup_config,
+            self.disk_kv_store,
+            self.precondition_hash,
+            self.precondition_validation_data_hash,
+            self.stitched_executions,
+            self.stitched_boot_info,
+            self.stitched_proofs,
+            self.prove_snark,
+            self.force_attempt,
+            self.seek_proof,
+        )
+        .await
+    }
+}
+
+impl PartialEq for Cached {
+    fn eq(&self, other: &Self) -> bool {
+        self.args.eq(&other.args)
+    }
+}
+
+impl Eq for Cached {}
+
+impl PartialOrd for Cached {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Cached {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.args.cmp(&other.args)
+    }
+}
+
+#[derive(Debug)]
+pub struct OneshotResult {
+    pub cached: Cached,
+    pub result: Result<Proof, ProvingError>,
+}
+
+impl PartialEq for OneshotResult {
+    fn eq(&self, other: &Self) -> bool {
+        self.cached.eq(&other.cached)
+    }
+}
+
+impl Eq for OneshotResult {}
+
+impl PartialOrd for OneshotResult {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for OneshotResult {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.cached.cmp(&other.cached)
+    }
+}
+
+#[derive(Debug)]
+pub struct Oneshot {
+    pub cached_task: Cached,
+    pub result_sender: Sender<OneshotResult>,
+}
+
+pub async fn handle_oneshot_tasks(task_receiver: Receiver<Oneshot>) -> anyhow::Result<()> {
+    loop {
+        let Oneshot {
+            cached_task,
+            result_sender,
+        } = task_receiver
+            .recv()
+            .await
+            .context("task receiver channel closed")?;
+
+        if let Err(res) = result_sender
+            .send(OneshotResult {
+                cached: cached_task.clone(),
+                result: cached_task.compute().await,
+            })
+            .await
+        {
+            error!("failed to send task result: {res:?}");
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn compute_oneshot_task(
+    args: KailuaHostArgs,
+    rollup_config: RollupConfig,
+    disk_kv_store: Option<RWLKeyValueStore>,
+    precondition_hash: B256,
+    precondition_validation_data_hash: B256,
+    stitched_executions: Vec<Vec<Execution>>,
+    stitched_boot_info: Vec<StitchedBootInfo>,
+    stitched_proofs: Vec<Proof>,
+    prove_snark: bool,
+    force_attempt: bool,
+    seek_proof: bool,
+    task_sender: Sender<Oneshot>,
+) -> Result<Proof, ProvingError> {
+    // create proving task
+    let cached_task = Cached {
+        args,
+        rollup_config,
+        disk_kv_store,
+        precondition_hash,
+        precondition_validation_data_hash,
+        stitched_executions,
+        stitched_boot_info,
+        stitched_proofs,
+        prove_snark,
+        force_attempt,
+        seek_proof,
+    };
+    // create onshot channel
+    let oneshot_channel = async_channel::bounded(1);
+    // dispatch task to pool
+    task_sender
+        .send(Oneshot {
+            cached_task,
+            result_sender: oneshot_channel.0,
+        })
+        .await
+        .expect("Oneshot channel closed");
+    // wait for result
+    oneshot_channel
+        .1
+        .recv()
+        .await
+        .expect("oneshot_channel should never panic")
+        .result
+}

--- a/book/src/validator.md
+++ b/book/src/validator.md
@@ -132,11 +132,12 @@ Running `kailua-cli validate` with the above extra arguments should now delegate
 ## Advanced Settings
 
 Fault/Validity proof generation can be fine-tuned via the two following environment variables:
-* `NUM_CONCURRENT_PROOFS`: The maximum number of proving tasks to run concurrently (Default 1).
+* `NUM_CONCURRENT_HOSTS`: (default 1) The maximum number of kailua-host instances to run concurrently in the validator.
+* `NUM_CONCURRENT_PREFLIGHTS`: (default 4) Sets the number of concurrent data preflights per proving task.
+* `NUM_CONCURRENT_PROOFS`: (default 1) Sets the number of concurrent proofs to seek per proving task.
 * `SEGMENT_LIMIT`: The [segment size limit](https://docs.rs/risc0-zkvm/1.2.3/risc0_zkvm/struct.ExecutorEnvBuilder.html#method.segment_limit_po2) used for local proving (Default 21).
 * `MAX_WITNESS_SIZE`: The maximum input size per single proof (Default 100MB).
 * `SKIP_ZETH_PREFLIGHT`: If set to false (defaults to true), performs a preflight to fetch witness data using zeth.
-* `NUM_PREFLIGHT_THREADS`: (default 4) Sets the number of concurrent threads to use for fetching preflight data.
 
 When manually computing individual proofs, the following parameters (or equiv. env. vars) take effect:
 * `SKIP_DERIVATION_PROOF`: Skips provably deriving L2 transactions using L1 data.

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -153,7 +153,7 @@ pub fn config_hash(rollup_config: &RollupConfig) -> anyhow::Result<[u8; 32]> {
             .0
             .as_slice(),
         safe_default(rollup_config.blobs_enabled_l1_timestamp, u64::MAX)
-            .context("blobs_enabled_timestmap")?
+            .context("blobs_enabled_timestamp")?
             .to_be_bytes()
             .as_slice(),
         safe_default(rollup_config.da_challenge_address, Address::ZERO)


### PR DESCRIPTION
Enables proving and preflight multithreading through three new controls:
* `NUM_CONCURRENT_HOSTS`: (default 1) The maximum number of kailua-host instances to run concurrently in the validator.
* `NUM_CONCURRENT_PREFLIGHTS`: (default 4) Sets the number of concurrent data preflights per proving task.
* `NUM_CONCURRENT_PROOFS`: (default 1) Sets the number of concurrent proofs to seek per proving task.
