### PR TITLE
fix: docker buildx cache fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,9 @@ WORKDIR /kailua
 
 COPY . .
 
-RUN --mount=type=cache,target=/root/.cargo/registry --mount=type=cache,target=/root/.cargo/git --mount=type=cache,target=/kailua/target \
-
+RUN --mount=type=cache,target=/root/.cargo/registry,sharing=shared \
+    --mount=type=cache,target=/root/.cargo/git,sharing=shared \
+    --mount=type=cache,target=/kailua/target,sharing=private,id=rust-target-${TARGETARCH} \
     cargo build --jobs ${CARGO_BUILD_JOBS} --release -F disable-dev-mode \
     && mkdir out \
     && mv target/release/kailua-host out/ \


### PR DESCRIPTION
When building on differing platforms using `docker buildx build .` the cache now persists between builds