### PR TITLE
fix: Prevent elimination after resolution

### DIFF
--- a/crates/contracts/foundry/src/KailuaTournament.sol
+++ b/crates/contracts/foundry/src/KailuaTournament.sol
@@ -308,6 +308,11 @@ abstract contract KailuaTournament is Clone, IDisputeGame {
         KailuaTournament contender = children[u];
         bytes32 contenderSignature = contender.signature();
 
+        // Ensure survivor decision finality after resolution
+        if (contender.status() == GameStatus.DEFENDER_WINS) {
+            return contender;
+        }
+
         // If the contender is invalid then we eliminate it and find the next viable contender using the opponent
         // pointer. This search could terminate early if the elimination limit is reached.
         // If the contender is valid and its proposer is not eliminated, this is skipped.


### PR DESCRIPTION
This fixes a corner case where a validity proof could be used to eliminate a (faulty) proposal after it had been finalized.