### PR TITLE
fix: Prevent any tournament state updates after resolution

### DIFF
--- a/crates/contracts/foundry/src/KailuaTournament.sol
+++ b/crates/contracts/foundry/src/KailuaTournament.sol
@@ -185,6 +185,11 @@ abstract contract KailuaTournament is Clone, IDisputeGame {
             revert InvalidParent();
         }
 
+        // INVARIANT: No longer accept proposals after resolution
+        if (contenderIndex < children.length && children[contenderIndex].status() == GameStatus.DEFENDER_WINS) {
+            revert ClaimAlreadyResolved();
+        }
+
         // Append new child to children list
         children.push(KailuaTournament(msg.sender));
     }
@@ -429,6 +434,11 @@ abstract contract KailuaTournament is Clone, IDisputeGame {
             revert AlreadyProven();
         }
 
+        // INVARIANT: No longer accept proofs after resolution
+        if (contenderIndex < children.length && children[contenderIndex].status() == GameStatus.DEFENDER_WINS) {
+            revert ClaimAlreadyResolved();
+        }
+
         // Calculate the expected precondition hash if blob data is necessary for proposal
         bytes32 preconditionHash = bytes32(0x0);
         if (PROPOSAL_OUTPUT_COUNT > 1) {
@@ -499,6 +509,11 @@ abstract contract KailuaTournament is Clone, IDisputeGame {
         // INVARIANT: Proofs can only be submitted once
         if (proofStatus[childSignature] != ProofStatus.NONE) {
             revert AlreadyProven();
+        }
+
+        // INVARIANT: No longer accept proofs after resolution
+        if (contenderIndex < children.length && children[contenderIndex].status() == GameStatus.DEFENDER_WINS) {
+            revert ClaimAlreadyResolved();
         }
 
         // INVARIANT: Proofs can only pertain to computed outputs
@@ -595,6 +610,11 @@ abstract contract KailuaTournament is Clone, IDisputeGame {
         // INVARIANT: Proofs can only be submitted once
         if (proofStatus[childSignature] != ProofStatus.NONE) {
             revert AlreadyProven();
+        }
+
+        // INVARIANT: No longer accept proofs after resolution
+        if (contenderIndex < children.length && children[contenderIndex].status() == GameStatus.DEFENDER_WINS) {
+            revert ClaimAlreadyResolved();
         }
 
         // INVARIANT: Proofs can only pertain to intermediate commitments

--- a/crates/contracts/foundry/test/Propose.t.sol
+++ b/crates/contracts/foundry/test/Propose.t.sol
@@ -155,7 +155,7 @@ contract ProposeTest is KailuaTest {
     function test_appendChild() public {
         vm.warp(
             game.GENESIS_TIME_STAMP() + game.PROPOSAL_TIME_GAP()
-                + game.PROPOSAL_OUTPUT_COUNT() * game.OUTPUT_BLOCK_SPAN() * game.L2_BLOCK_TIME() * 1
+                + game.PROPOSAL_OUTPUT_COUNT() * game.OUTPUT_BLOCK_SPAN() * game.L2_BLOCK_TIME() * 2
         );
         // Succeed on fresh proposal
         uint64 anchorIndex = uint64(anchor.gameIndex());
@@ -163,9 +163,20 @@ contract ProposeTest is KailuaTest {
             Claim.wrap(0x0001010000010100000010100000101000001010000010100000010100000101),
             abi.encodePacked(uint64(128), anchorIndex, uint64(0))
         );
-        // Fail to call append child
+
+        // Fail to call append child outside treasury
         vm.expectRevert(UnknownGame.selector);
         proposal_128_0.appendChild();
+
+        // Fail to append child after resolution
+        proposal_128_0.resolve();
+        vm.startPrank(address(0x0));
+        vm.expectRevert(ClaimAlreadyResolved.selector);
+        treasury.propose(
+            Claim.wrap(0x0001010000010100000010100000101000001010000010100000010100000101),
+            abi.encodePacked(uint64(128), anchorIndex, uint64(1))
+        );
+        vm.stopPrank();
     }
 
     function test_proposerOf() public {


### PR DESCRIPTION
This prevents proof submission after a child has been resolved to prevent any potential side effects.