### PR TITLE
feat: Relax withdrawal restrictions on uneliminated players

### DIFF
--- a/crates/contracts/foundry/src/KailuaTreasury.sol
+++ b/crates/contracts/foundry/src/KailuaTreasury.sol
@@ -270,10 +270,16 @@ contract KailuaTreasury is KailuaTournament, IKailuaTreasury {
 
     /// @notice Pays the proposer back its bond
     function claimProposerBond() public nonReentrant {
+        // INVARIANT: Can only claim back bond if not eliminated
+        if (eliminationRound[msg.sender] != 0) {
+            revert AlreadyEliminated();
+        }
+
         // INVARIANT: Can only claim bond back if no pending proposals are left
         KailuaTournament previousGame = lastProposal[msg.sender];
         if (address(previousGame) != address(0x0)) {
-            if (previousGame.status() != GameStatus.DEFENDER_WINS) {
+            KailuaTournament lastTournament = previousGame.parentGame();
+            if (lastTournament.children(lastTournament.contenderIndex()).status() != GameStatus.DEFENDER_WINS) {
                 revert GameNotResolved();
             }
         }

--- a/crates/contracts/foundry/test/ClaimDispute.t.sol
+++ b/crates/contracts/foundry/test/ClaimDispute.t.sol
@@ -392,6 +392,17 @@ contract ClaimDisputeTest is KailuaTest {
             Claim.wrap(0x0001010000010100000010100000101000001010000010100000010100000101),
             abi.encodePacked(uint64(128), parentIndex, uint64(1))
         );
+
+        // Fail to recover proposer bond due to hanging proposal
+        vm.expectRevert(GameNotResolved.selector);
+        treasury.claimProposerBond();
+
+        // Eliminate player
+        proposal_128_0.parentGame().pruneChildren(1);
+
+        // Fail to recover proposer bond due to elimination
+        vm.expectRevert(AlreadyEliminated.selector);
+        treasury.claimProposerBond();
     }
 
     function test_proveOutputFault_disputed() public {


### PR DESCRIPTION
Players that submit correct duplicate proposals or late proposals not considered in the tournament are no longer restricted from withdrawal, even if the late proposal is faulty.