### PR TITLE
chore: Update `boundless-market` to 0.11.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ optimism/
 profiling/*
 kailua-elf
 kailua-input
-.req
+*.req

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ optimism/
 profiling/*
 kailua-elf
 kailua-input
+.req

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,26 +91,47 @@ version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3287a60462d933cbc753a1a87439016d4eb717401f3052ff72742c6dd0dbce3f"
 dependencies = [
- "alloy-consensus",
- "alloy-contract",
+ "alloy-consensus 0.15.9",
+ "alloy-contract 0.15.6",
  "alloy-core",
  "alloy-eips 0.15.9",
- "alloy-genesis",
- "alloy-network",
- "alloy-node-bindings",
- "alloy-provider",
+ "alloy-network 0.15.9",
+ "alloy-provider 0.15.9",
  "alloy-pubsub",
- "alloy-rpc-client",
- "alloy-rpc-types",
+ "alloy-rpc-client 0.15.9",
+ "alloy-rpc-types 0.15.9",
  "alloy-serde 0.15.9",
- "alloy-signer",
+ "alloy-signer 0.15.9",
  "alloy-signer-aws",
  "alloy-signer-gcp",
- "alloy-signer-local",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-signer-local 0.15.6",
+ "alloy-transport 0.15.9",
+ "alloy-transport-http 0.15.9",
  "alloy-transport-ipc",
  "alloy-transport-ws",
+]
+
+[[package]]
+name = "alloy"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0093d23bf026b580c1f66ed3a053d8209c104a446c5264d3ad99587f6edef24e"
+dependencies = [
+ "alloy-consensus 1.0.16",
+ "alloy-contract 1.0.9",
+ "alloy-core",
+ "alloy-eips 1.0.16",
+ "alloy-genesis",
+ "alloy-network 1.0.16",
+ "alloy-node-bindings",
+ "alloy-provider 1.0.16",
+ "alloy-rpc-client 1.0.16",
+ "alloy-rpc-types 1.0.16",
+ "alloy-serde 1.0.16",
+ "alloy-signer 1.0.16",
+ "alloy-signer-local 1.0.16",
+ "alloy-transport 1.0.16",
+ "alloy-transport-http 1.0.16",
 ]
 
 [[package]]
@@ -135,7 +156,32 @@ dependencies = [
  "alloy-primitives 1.2.0",
  "alloy-rlp",
  "alloy-serde 0.15.9",
- "alloy-trie",
+ "alloy-trie 0.8.1",
+ "auto_impl",
+ "c-kzg",
+ "derive_more 2.0.1",
+ "either",
+ "k256",
+ "once_cell",
+ "rand 0.8.5",
+ "secp256k1",
+ "serde",
+ "serde_with",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b77018eec2154eb158869f9f2914a3ea577adf87b11be2764d4795d5ccccf7"
+dependencies = [
+ "alloy-eips 1.0.16",
+ "alloy-primitives 1.2.0",
+ "alloy-rlp",
+ "alloy-serde 1.0.16",
+ "alloy-trie 0.9.0",
+ "alloy-tx-macros",
  "auto_impl",
  "c-kzg",
  "derive_more 2.0.1",
@@ -155,11 +201,25 @@ version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a16df75c656be4465ab411b88c5ec6bae4931ce806834efbf375ca85b8db6f9a"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.9",
  "alloy-eips 0.15.9",
  "alloy-primitives 1.2.0",
  "alloy-rlp",
  "alloy-serde 0.15.9",
+ "serde",
+]
+
+[[package]]
+name = "alloy-consensus-any"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bf8b058ff364d6e94bcd2979d7da1862e94d2987065a4eb41fa9eac36e028a"
+dependencies = [
+ "alloy-consensus 1.0.16",
+ "alloy-eips 1.0.16",
+ "alloy-primitives 1.2.0",
+ "alloy-rlp",
+ "alloy-serde 1.0.16",
  "serde",
 ]
 
@@ -169,17 +229,38 @@ version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "258feff52f1e3be58b4d235ef85f5c0224905e371fb023dfbf758d5a7e027672"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.9",
  "alloy-dyn-abi",
  "alloy-json-abi 1.2.0",
- "alloy-network",
- "alloy-network-primitives",
+ "alloy-network 0.15.9",
+ "alloy-network-primitives 0.15.9",
  "alloy-primitives 1.2.0",
- "alloy-provider",
+ "alloy-provider 0.15.9",
  "alloy-pubsub",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 0.15.9",
  "alloy-sol-types",
- "alloy-transport",
+ "alloy-transport 0.15.9",
+ "futures",
+ "futures-util",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-contract"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf25443920ecb9728cb087fe4dc04a0b290bd6ac85638c58fe94aba70f1a44e"
+dependencies = [
+ "alloy-consensus 1.0.16",
+ "alloy-dyn-abi",
+ "alloy-json-abi 1.2.0",
+ "alloy-network 1.0.16",
+ "alloy-network-primitives 1.0.16",
+ "alloy-primitives 1.2.0",
+ "alloy-provider 1.0.16",
+ "alloy-rpc-types-eth 1.0.16",
+ "alloy-sol-types",
+ "alloy-transport 1.0.16",
  "futures",
  "futures-util",
  "thiserror 2.0.12",
@@ -293,12 +374,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-eips"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d134f3ac4926124eaf521a1031d11ea98816df3d39fc446fcfd6b36884603f"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-primitives 1.2.0",
+ "alloy-rlp",
+ "alloy-serde 1.0.16",
+ "auto_impl",
+ "c-kzg",
+ "derive_more 2.0.1",
+ "either",
+ "serde",
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "alloy-evm"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb232f8e0e6bac6e28da4e4813331be06b7519949c043ba6c58b9228bab89983"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.9",
  "alloy-eips 0.15.9",
  "alloy-hardforks",
  "alloy-primitives 1.2.0",
@@ -313,14 +414,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.15.11"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f723856b1c4ad5473f065650ab9be557c96fbc77e89180fbdac003e904a8d6"
+checksum = "fb1c2792605e648bdd1fddcfed8ce0d39d3db495c71d2240cb53df8aee8aea1f"
 dependencies = [
- "alloy-eips 0.15.9",
+ "alloy-eips 1.0.16",
  "alloy-primitives 1.2.0",
- "alloy-serde 0.15.9",
- "alloy-trie",
+ "alloy-serde 1.0.16",
+ "alloy-trie 0.9.0",
  "serde",
 ]
 
@@ -376,21 +477,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-json-rpc"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31cfdacfeb6b6b40bf6becf92e69e575c68c9f80311c3961d019e29c0b8d6be2"
+dependencies = [
+ "alloy-primitives 1.2.0",
+ "alloy-sol-types",
+ "http 1.2.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
 name = "alloy-network"
 version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adf68d6a8664c89847905b63fef561c54fd9ecb42ef92053e7935a61b8ec453e"
 dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
+ "alloy-consensus 0.15.9",
+ "alloy-consensus-any 0.15.6",
  "alloy-eips 0.15.9",
- "alloy-json-rpc",
- "alloy-network-primitives",
+ "alloy-json-rpc 0.15.6",
+ "alloy-network-primitives 0.15.9",
  "alloy-primitives 1.2.0",
- "alloy-rpc-types-any",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-any 0.15.6",
+ "alloy-rpc-types-eth 0.15.9",
  "alloy-serde 0.15.9",
- "alloy-signer",
+ "alloy-signer 0.15.9",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "derive_more 2.0.1",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-network"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de68a3f09cd9ab029cf87d08630e1336ca9a530969689fd151d505fa888a2603"
+dependencies = [
+ "alloy-consensus 1.0.16",
+ "alloy-consensus-any 1.0.16",
+ "alloy-eips 1.0.16",
+ "alloy-json-rpc 1.0.16",
+ "alloy-network-primitives 1.0.16",
+ "alloy-primitives 1.2.0",
+ "alloy-rpc-types-any 1.0.16",
+ "alloy-rpc-types-eth 1.0.16",
+ "alloy-serde 1.0.16",
+ "alloy-signer 1.0.16",
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
@@ -407,7 +549,7 @@ version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a83c70f1509416f905f809a27006d3b8e2005d9d1e4aeee994882ae0397477c5"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.9",
  "alloy-eips 0.15.9",
  "alloy-primitives 1.2.0",
  "alloy-serde 0.15.9",
@@ -415,17 +557,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-node-bindings"
-version = "0.15.11"
+name = "alloy-network-primitives"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c4bde7223db742a6cb2ab61d99bc37e741d1447b60dfe5fe87405aae96741f"
+checksum = "fcc2689c8addfc43461544d07a6f5f3a3e1f5f4efae61206cb5783dc383cfc8f"
+dependencies = [
+ "alloy-consensus 1.0.16",
+ "alloy-eips 1.0.16",
+ "alloy-primitives 1.2.0",
+ "alloy-serde 1.0.16",
+ "serde",
+]
+
+[[package]]
+name = "alloy-node-bindings"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "638b7551f1819023c41765416b75b3959ebe45bb174969cd20ee3b5f2e72c75d"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
- "alloy-network",
+ "alloy-network 1.0.16",
  "alloy-primitives 1.2.0",
- "alloy-signer",
- "alloy-signer-local",
+ "alloy-signer 1.0.16",
+ "alloy-signer-local 1.0.16",
  "k256",
  "rand 0.8.5",
  "serde_json",
@@ -441,7 +596,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b65600baa6f3638a8ca71460ef008a8dae45d941e93ec17ce9c33b469ab38fc"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.9",
  "alloy-eips 0.15.9",
  "alloy-evm",
  "alloy-op-hardforks",
@@ -524,24 +679,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64578f486297b27de47434f45659d3648e3326e195dab596e8a4161e91723bd5"
 dependencies = [
  "alloy-chains",
- "alloy-consensus",
+ "alloy-consensus 0.15.9",
  "alloy-eips 0.15.9",
- "alloy-json-rpc",
- "alloy-network",
- "alloy-network-primitives",
- "alloy-node-bindings",
+ "alloy-json-rpc 0.15.6",
+ "alloy-network 0.15.9",
+ "alloy-network-primitives 0.15.9",
  "alloy-primitives 1.2.0",
  "alloy-pubsub",
- "alloy-rpc-client",
- "alloy-rpc-types-anvil",
+ "alloy-rpc-client 0.15.9",
+ "alloy-rpc-types-anvil 0.15.6",
  "alloy-rpc-types-debug",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 0.15.9",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-signer",
+ "alloy-signer 0.15.9",
  "alloy-sol-types",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-transport 0.15.9",
+ "alloy-transport-http 0.15.9",
  "alloy-transport-ipc",
  "alloy-transport-ws",
  "async-stream",
@@ -565,14 +719,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-provider"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ced931220f547d30313530ad315654b7862ef52631c90ab857d792865f84a7d"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus 1.0.16",
+ "alloy-eips 1.0.16",
+ "alloy-json-rpc 1.0.16",
+ "alloy-network 1.0.16",
+ "alloy-network-primitives 1.0.16",
+ "alloy-node-bindings",
+ "alloy-primitives 1.2.0",
+ "alloy-rpc-client 1.0.16",
+ "alloy-rpc-types-anvil 1.0.16",
+ "alloy-rpc-types-eth 1.0.16",
+ "alloy-signer 1.0.16",
+ "alloy-sol-types",
+ "alloy-transport 1.0.16",
+ "alloy-transport-http 1.0.16",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap",
+ "either",
+ "futures",
+ "futures-utils-wasm",
+ "http 1.2.0",
+ "lru 0.13.0",
+ "parking_lot",
+ "pin-project 1.1.9",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
 name = "alloy-pubsub"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fbf7f3b22f7d34eb9aedf637bcdc5d4f47f5e028d3f7520f6ecc7fc75a7a027"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 0.15.6",
  "alloy-primitives 1.2.0",
- "alloy-transport",
+ "alloy-transport 0.15.9",
  "bimap",
  "futures",
  "parking_lot",
@@ -613,13 +809,38 @@ version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00bb8eb6eeeb6ba57a49e77cc73169ba099081daedb9596f61d91e27cfb8a012"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 0.15.6",
  "alloy-primitives 1.2.0",
  "alloy-pubsub",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-transport 0.15.9",
+ "alloy-transport-http 0.15.9",
  "alloy-transport-ipc",
  "alloy-transport-ws",
+ "async-stream",
+ "futures",
+ "pin-project 1.1.9",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.2",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1d1eac6e48b772c7290f0f79211a0e822a38b057535b514cc119abd857d5b6"
+dependencies = [
+ "alloy-json-rpc 1.0.16",
+ "alloy-primitives 1.2.0",
+ "alloy-transport 1.0.16",
+ "alloy-transport-http 1.0.16",
  "async-stream",
  "futures",
  "pin-project 1.1.9",
@@ -642,13 +863,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "815e430440eadcf61d7ea90dab5642bcf72056a8eacaffb97820d3a41fcdc0da"
 dependencies = [
  "alloy-primitives 1.2.0",
- "alloy-rpc-types-anvil",
+ "alloy-rpc-types-anvil 0.15.6",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 0.15.9",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
  "alloy-serde 0.15.9",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8589c6ae318fcc9624d42e9166f7f82b630d9ad13e180c52addf20b93a8af266"
+dependencies = [
+ "alloy-primitives 1.2.0",
+ "alloy-rpc-types-eth 1.0.16",
+ "alloy-serde 1.0.16",
  "serde",
 ]
 
@@ -659,8 +892,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8702ccf7d241cb52fc6730561f7429c15158dacffe68c9127d2ab79d1657b862"
 dependencies = [
  "alloy-primitives 1.2.0",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 0.15.9",
  "alloy-serde 0.15.9",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-anvil"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754d5062b594ed300a3bb0df615acb7bacdbd7bd1cd1a6e5b59fb936c5025a13"
+dependencies = [
+ "alloy-primitives 1.2.0",
+ "alloy-rpc-types-eth 1.0.16",
+ "alloy-serde 1.0.16",
  "serde",
 ]
 
@@ -670,9 +915,20 @@ version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93017fb350fe2c0cccda41f9be45352012696a5fbd08c5fef4be0df838999bfa"
 dependencies = [
- "alloy-consensus-any",
- "alloy-rpc-types-eth",
+ "alloy-consensus-any 0.15.6",
+ "alloy-rpc-types-eth 0.15.9",
  "alloy-serde 0.15.9",
+]
+
+[[package]]
+name = "alloy-rpc-types-any"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02cfd7ecb21a1bfe68ac6b551172e4d41f828bcc33a2e1563a65d482d4efc1cf"
+dependencies = [
+ "alloy-consensus-any 1.0.16",
+ "alloy-rpc-types-eth 1.0.16",
+ "alloy-serde 1.0.16",
 ]
 
 [[package]]
@@ -705,7 +961,7 @@ version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e228902dd802e9af385ca9d511f1556b647bf651d65574ae5e198447db96eaf"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.9",
  "alloy-eips 0.15.9",
  "alloy-primitives 1.2.0",
  "alloy-rlp",
@@ -723,13 +979,33 @@ version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f2530ba812172a7749b7af9bfbcb94cd555109e0a97458716b4543c36b81339"
 dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
+ "alloy-consensus 0.15.9",
+ "alloy-consensus-any 0.15.6",
  "alloy-eips 0.15.9",
- "alloy-network-primitives",
+ "alloy-network-primitives 0.15.9",
  "alloy-primitives 1.2.0",
  "alloy-rlp",
  "alloy-serde 0.15.9",
+ "alloy-sol-types",
+ "itertools 0.14.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-rpc-types-eth"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb082c325bdfd05a7c71f52cd1060e62491fbf6edf55962720bdc380847b0784"
+dependencies = [
+ "alloy-consensus 1.0.16",
+ "alloy-consensus-any 1.0.16",
+ "alloy-eips 1.0.16",
+ "alloy-network-primitives 1.0.16",
+ "alloy-primitives 1.2.0",
+ "alloy-rlp",
+ "alloy-serde 1.0.16",
  "alloy-sol-types",
  "itertools 0.14.0",
  "serde",
@@ -744,7 +1020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c24a733a999bbfa706d03f54332ad03697e745ed27c25bdeebac39586f184d8"
 dependencies = [
  "alloy-primitives 1.2.0",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 0.15.9",
  "alloy-serde 0.15.9",
  "serde",
  "serde_json",
@@ -758,7 +1034,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6d62259b6e1469042a21807d5f24002a7a0f30f69e945ded82ed6009fd1e50"
 dependencies = [
  "alloy-primitives 1.2.0",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 0.15.9",
  "alloy-serde 0.15.9",
  "serde",
 ]
@@ -786,10 +1062,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-serde"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f26c17270c2ac1bd555c4304fe067639f0ddafdd3c8d07a200b2bb5a326e03"
+dependencies = [
+ "alloy-primitives 1.2.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "alloy-signer"
 version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c37f6e07803121bd9597058f83726f7dc316fc630a0dad61c3c7a1fb784303c5"
+dependencies = [
+ "alloy-primitives 1.2.0",
+ "async-trait",
+ "auto_impl",
+ "either",
+ "elliptic-curve 0.13.8",
+ "k256",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-signer"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d9fd649d6ed5b8d7e5014e01758efb937e8407124b182a7f711bf487a1a2697"
 dependencies = [
  "alloy-primitives 1.2.0",
  "async-trait",
@@ -806,10 +1108,10 @@ version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "415670220e0739be8b0bd419e4db3ebd1886ec281ed6b43818a45b65fe0eef9d"
 dependencies = [
- "alloy-consensus",
- "alloy-network",
+ "alloy-consensus 0.15.9",
+ "alloy-network 0.15.9",
  "alloy-primitives 1.2.0",
- "alloy-signer",
+ "alloy-signer 0.15.9",
  "async-trait",
  "aws-sdk-kms",
  "k256",
@@ -824,10 +1126,10 @@ version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d53ce0b64d32641ac254983841c9fe874ab80cc0036835a8d9c09cbdedcebb2"
 dependencies = [
- "alloy-consensus",
- "alloy-network",
+ "alloy-consensus 0.15.9",
+ "alloy-network 0.15.9",
  "alloy-primitives 1.2.0",
- "alloy-signer",
+ "alloy-signer 0.15.9",
  "async-trait",
  "gcloud-sdk",
  "k256",
@@ -842,10 +1144,26 @@ version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f8d1f2edc446b52985a5af71cdbce86e8646865b889e38410594eea97804380"
 dependencies = [
- "alloy-consensus",
- "alloy-network",
+ "alloy-consensus 0.15.9",
+ "alloy-network 0.15.9",
  "alloy-primitives 1.2.0",
- "alloy-signer",
+ "alloy-signer 0.15.9",
+ "async-trait",
+ "k256",
+ "rand 0.8.5",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-signer-local"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c288c5b38be486bb84986701608f5d815183de990e884bb747f004622783e125"
+dependencies = [
+ "alloy-consensus 1.0.16",
+ "alloy-network 1.0.16",
+ "alloy-primitives 1.2.0",
+ "alloy-signer 1.0.16",
  "async-trait",
  "k256",
  "rand 0.8.5",
@@ -941,7 +1259,30 @@ version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c30aa026c88924cfa89ddfa77ad77aec05d2153c6838422dcdaf559a6e9e3175"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 0.15.6",
+ "alloy-primitives 1.2.0",
+ "base64 0.22.1",
+ "derive_more 2.0.1",
+ "futures",
+ "futures-utils-wasm",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tower 0.5.2",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b790b89e31e183ae36ac0a1419942e21e94d745066f5281417c3e4299ea39e"
+dependencies = [
+ "alloy-json-rpc 1.0.16",
  "alloy-primitives 1.2.0",
  "base64 0.22.1",
  "derive_more 2.0.1",
@@ -964,9 +1305,9 @@ version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3259b177d89bb02599bddb4cd3c11ec5a1ffdaaa01a2706e8298e08433f205f0"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 0.15.6",
  "alloy-rpc-types-engine",
- "alloy-transport",
+ "alloy-transport 0.15.9",
  "http-body-util",
  "hyper 1.6.0",
  "hyper-tls",
@@ -980,14 +1321,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-transport-http"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f643645a33a681d09ac1ca2112014c2ca09c68aad301da4400484d59c746bc70"
+dependencies = [
+ "alloy-json-rpc 1.0.16",
+ "alloy-transport 1.0.16",
+ "reqwest",
+ "serde_json",
+ "tower 0.5.2",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "alloy-transport-ipc"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a0cad5f19f718b83d4a52ebc12f3b691b245111e50403d2adfd46674bc73da8"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 0.15.6",
  "alloy-pubsub",
- "alloy-transport",
+ "alloy-transport 0.15.9",
  "bytes",
  "futures",
  "interprocess",
@@ -1006,7 +1362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f48cc4f88d59463992251b89381760be901c4789a4721c657b832994331aff05"
 dependencies = [
  "alloy-pubsub",
- "alloy-transport",
+ "alloy-transport 0.15.9",
  "futures",
  "http 1.2.0",
  "rustls 0.23.23",
@@ -1027,10 +1383,39 @@ dependencies = [
  "alloy-rlp",
  "arrayvec",
  "derive_more 2.0.1",
- "nybbles",
+ "nybbles 0.3.4",
  "serde",
  "smallvec",
  "tracing",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bada1fc392a33665de0dc50d401a3701b62583c655e3522a323490a5da016962"
+dependencies = [
+ "alloy-primitives 1.2.0",
+ "alloy-rlp",
+ "arrayvec",
+ "derive_more 2.0.1",
+ "nybbles 0.4.0",
+ "serde",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-tx-macros"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ef40a046b9bf141afc440cef596c79292708aade57c450dc74e843270fd8e7"
+dependencies = [
+ "alloy-primitives 1.2.0",
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2555,11 +2940,12 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d936359169584120ced4ca5208231e9cc1845591d13d559e6240e14ed878d6a8"
+checksum = "fbbcd8220a3c1ae1740ee7f4df3c78512dc8798ad05308c596aac4844d124087"
 dependencies = [
- "alloy",
+ "alloy 1.0.9",
+ "alloy-chains",
  "alloy-primitives 1.2.0",
  "alloy-sol-types",
  "anyhow",
@@ -2569,6 +2955,9 @@ dependencies = [
  "bytemuck",
  "chrono",
  "clap",
+ "dashmap",
+ "derive_builder",
+ "futures",
  "futures-util",
  "hex",
  "httpmock",
@@ -5013,7 +5402,7 @@ dependencies = [
 name = "kailua-cli"
 version = "1.0.0-rc.1"
 dependencies = [
- "alloy",
+ "alloy 0.15.6",
  "anyhow",
  "bytemuck",
  "clap",
@@ -5041,7 +5430,7 @@ dependencies = [
 name = "kailua-common"
 version = "1.0.0-rc.1"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.9",
  "alloy-eips 0.15.9",
  "alloy-evm",
  "alloy-op-evm",
@@ -5082,7 +5471,7 @@ dependencies = [
 name = "kailua-contracts"
 version = "1.0.0-rc.1"
 dependencies = [
- "alloy",
+ "alloy 0.15.6",
  "foundry-compilers",
 ]
 
@@ -5090,7 +5479,7 @@ dependencies = [
 name = "kailua-proposer"
 version = "1.0.0-rc.1"
 dependencies = [
- "alloy",
+ "alloy 0.15.6",
  "anyhow",
  "clap",
  "kailua-common",
@@ -5106,7 +5495,7 @@ dependencies = [
 name = "kailua-prover"
 version = "1.0.0-rc.1"
 dependencies = [
- "alloy",
+ "alloy 0.15.6",
  "alloy-primitives 1.2.0",
  "anyhow",
  "async-channel 2.3.1",
@@ -5145,7 +5534,7 @@ dependencies = [
 name = "kailua-sync"
 version = "1.0.0-rc.1"
 dependencies = [
- "alloy",
+ "alloy 0.15.6",
  "alloy-rpc-types-beacon",
  "anyhow",
  "async-trait",
@@ -5179,7 +5568,7 @@ dependencies = [
 name = "kailua-validator"
 version = "1.0.0-rc.1"
 dependencies = [
- "alloy",
+ "alloy 0.15.6",
  "anyhow",
  "async-channel 2.3.1",
  "bytemuck",
@@ -5234,7 +5623,7 @@ name = "kona-client"
 version = "1.0.1"
 source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.9",
  "alloy-eips 0.15.9",
  "alloy-evm",
  "alloy-op-evm",
@@ -5273,7 +5662,7 @@ name = "kona-derive"
 version = "0.3.0"
 source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.9",
  "alloy-eips 0.15.9",
  "alloy-primitives 1.2.0",
  "alloy-rlp",
@@ -5294,7 +5683,7 @@ name = "kona-driver"
 version = "0.3.0"
 source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.9",
  "alloy-evm",
  "alloy-primitives 1.2.0",
  "alloy-rlp",
@@ -5315,14 +5704,14 @@ name = "kona-executor"
 version = "0.3.0"
 source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.9",
  "alloy-eips 0.15.9",
  "alloy-evm",
  "alloy-op-evm",
  "alloy-op-hardforks",
  "alloy-primitives 1.2.0",
  "alloy-rlp",
- "alloy-trie",
+ "alloy-trie 0.8.1",
  "kona-genesis",
  "kona-mpt",
  "kona-protocol",
@@ -5339,7 +5728,7 @@ name = "kona-genesis"
 version = "0.3.0"
 source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.9",
  "alloy-eips 0.15.9",
  "alloy-hardforks",
  "alloy-op-hardforks",
@@ -5369,18 +5758,18 @@ name = "kona-host"
 version = "1.0.1"
 source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.9",
  "alloy-eips 0.15.9",
  "alloy-op-evm",
  "alloy-primitives 1.2.0",
- "alloy-provider",
+ "alloy-provider 0.15.9",
  "alloy-rlp",
- "alloy-rpc-client",
- "alloy-rpc-types",
+ "alloy-rpc-client 0.15.9",
+ "alloy-rpc-types 0.15.9",
  "alloy-rpc-types-beacon",
  "alloy-serde 0.15.9",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-transport 0.15.9",
+ "alloy-transport-http 0.15.9",
  "anyhow",
  "ark-ff 0.5.0",
  "async-trait",
@@ -5417,7 +5806,7 @@ name = "kona-interop"
 version = "0.3.0"
 source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.9",
  "alloy-eips 0.15.9",
  "alloy-primitives 1.2.0",
  "alloy-rlp",
@@ -5440,7 +5829,7 @@ source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a
 dependencies = [
  "alloy-primitives 1.2.0",
  "alloy-rlp",
- "alloy-trie",
+ "alloy-trie 0.8.1",
  "op-alloy-rpc-types-engine",
  "serde",
  "thiserror 2.0.12",
@@ -5465,13 +5854,13 @@ name = "kona-proof"
 version = "0.3.0"
 source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.9",
  "alloy-eips 0.15.9",
  "alloy-evm",
  "alloy-op-evm",
  "alloy-primitives 1.2.0",
  "alloy-rlp",
- "alloy-trie",
+ "alloy-trie 0.8.1",
  "ark-bls12-381",
  "ark-ff 0.5.0",
  "async-trait",
@@ -5501,7 +5890,7 @@ name = "kona-proof-interop"
 version = "0.2.0"
 source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.9",
  "alloy-eips 0.15.9",
  "alloy-evm",
  "alloy-op-evm",
@@ -5534,12 +5923,12 @@ version = "0.3.0"
 source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
  "alloc-no-stdlib",
- "alloy-consensus",
+ "alloy-consensus 0.15.9",
  "alloy-eips 0.15.9",
  "alloy-primitives 1.2.0",
  "alloy-rlp",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 0.15.9",
  "alloy-serde 0.15.9",
  "async-trait",
  "brotli",
@@ -5562,16 +5951,16 @@ name = "kona-providers-alloy"
 version = "0.2.0"
 source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.9",
  "alloy-eips 0.15.9",
  "alloy-primitives 1.2.0",
- "alloy-provider",
- "alloy-rpc-client",
+ "alloy-provider 0.15.9",
+ "alloy-rpc-client 0.15.9",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-engine",
  "alloy-serde 0.15.9",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-transport 0.15.9",
+ "alloy-transport-http 0.15.9",
  "async-trait",
  "http-body-util",
  "kona-derive",
@@ -6425,6 +6814,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nybbles"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d51b0175c49668a033fe7cc69080110d9833b291566cdf332905f3ad9c68a0"
+dependencies = [
+ "alloy-rlp",
+ "proptest",
+ "ruint",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6465,7 +6867,7 @@ version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375b501fad264f16781b608252b1b14c627359cc90cc09e80f6cbdac03fd8f07"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.9",
  "alloy-eips 0.15.9",
  "alloy-primitives 1.2.0",
  "alloy-rlp",
@@ -6481,11 +6883,11 @@ version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e65a776c7783650a4ffdf15bdf0526f4b8bdbe00b26df5aeeb1aa2939c6554f"
 dependencies = [
- "alloy-consensus",
- "alloy-network",
+ "alloy-consensus 0.15.9",
+ "alloy-network 0.15.9",
  "alloy-primitives 1.2.0",
- "alloy-rpc-types-eth",
- "alloy-signer",
+ "alloy-rpc-types-eth 0.15.9",
+ "alloy-signer 0.15.9",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
 ]
@@ -6496,11 +6898,11 @@ version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1436a5d45b7620bbba236201236ef644abd943258b6349dc5e5a147d65a1fac4"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.9",
  "alloy-eips 0.15.9",
- "alloy-network-primitives",
+ "alloy-network-primitives 0.15.9",
  "alloy-primitives 1.2.0",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 0.15.9",
  "alloy-serde 0.15.9",
  "derive_more 2.0.1",
  "op-alloy-consensus",
@@ -6514,7 +6916,7 @@ version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9767e25626d237857803577081a27082b2fd367934953e1144af433b1f4e07"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.9",
  "alloy-eips 0.15.9",
  "alloy-primitives 1.2.0",
  "alloy-rlp",
@@ -8008,11 +8410,11 @@ dependencies = [
 
 [[package]]
 name = "risc0-ethereum-contracts"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f1b5ad6f17421d94b198c3613bf883af84905cd34e7249fc1e8ebd69519c29"
+checksum = "6ce9bff70d4e50abcdae7f25aaac0460f39badca2d01f4a328320bf2564c1f06"
 dependencies = [
- "alloy",
+ "alloy 1.0.9",
  "alloy-primitives 1.2.0",
  "alloy-sol-types",
  "anyhow",
@@ -8263,9 +8665,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a46eb779843b2c4f21fac5773e25d6d5b7c8f0922876c91541790d2ca27eef"
+checksum = "11256b5fe8c68f56ac6f39ef0720e592f33d2367a4782740d9c9142e889c7fb4"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5523,6 +5523,7 @@ dependencies = [
  "risc0-ethereum-contracts",
  "risc0-zkvm",
  "rkyv",
+ "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ risc0-ethereum-contracts = "2.1.0"
 risc0-zkvm = { version = "2.1.0", features = ["heap-embedded-alloc", "unstable"] }
 
 # Boundless
-boundless-market = "0.8.0"
+boundless-market = "0.11.0"
 
 [profile.dev]
 opt-level = 3

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -21,6 +21,7 @@ clap.workspace = true
 hex.workspace = true
 human_bytes.workspace = true
 rkyv.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true

--- a/crates/prover/src/backends/boundless.rs
+++ b/crates/prover/src/backends/boundless.rs
@@ -482,7 +482,6 @@ pub async fn run_boundless_client(
                 .min_price(min_price)
                 .max_price(max_price)
                 .ramp_up_period((market.boundless_order_ramp_up_factor * segment_count) as u32)
-                // todo: .lock_stake(max_price)
                 .lock_timeout((lock_timeout_factor * segment_count) as u32)
                 .timeout((expiry_factor * segment_count) as u32)
                 .build()
@@ -549,24 +548,9 @@ pub async fn retrieve_proof(
     Ok(*receipt)
 }
 
-pub fn request_file_name(
-    proof_journal: &ProofJournal,
-    // boundless_chain_id: u64,
-    // boundless_market_address: Address,
-    // set_verifier_address: Address,
-    // verifier_router_address: Option<Address>,
-) -> String {
+pub fn request_file_name(proof_journal: &ProofJournal) -> String {
     let journal_hash = keccak256(proof_journal.encode_packed());
-    // todo: integrate market config
-    // let verifier_router_address = verifier_router_address.unwrap_or_default();
-    // let data = [
-    //     journal_hash.0.as_slice(),
-    //     boundless_chain_id.to_be_bytes().as_slice(),
-    //     boundless_market_address.0.as_slice(),
-    //     set_verifier_address.0.as_slice(),
-    //     verifier_router_address.as_slice()
-    // ].concat();
-    format!("boundless-{}.req", journal_hash)
+    format!("boundless-{journal_hash}.req")
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/prover/src/backends/boundless.rs
+++ b/crates/prover/src/backends/boundless.rs
@@ -35,8 +35,8 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::time::Duration;
 use tokio::time::sleep;
-use tracing::info;
 use tracing::log::warn;
+use tracing::{debug, info};
 
 #[derive(Parser, Clone, Debug, Default)]
 pub struct BoundlessArgs {
@@ -304,6 +304,13 @@ pub async fn run_boundless_client(
         .await
         .context("ClientBuilder::build()")
         .map_err(|e| ProvingError::OtherError(anyhow!(e)))?;
+
+    // Report boundless deployment info
+    info!(
+        "Using BoundlessMarket at {}",
+        boundless_client.deployment.boundless_market_address,
+    );
+    debug!("Deployment: {:?}", boundless_client.deployment);
 
     // Set the proof request requirements
     let requirements = Requirements::new(KAILUA_FPVM_ID, Predicate::digest_match(journal.digest()))

--- a/crates/prover/src/backends/boundless.rs
+++ b/crates/prover/src/backends/boundless.rs
@@ -188,7 +188,7 @@ impl MarketProviderConfig {
             self.boundless_order_ramp_up_factor.to_string(),
             String::from("--boundless-order-lock-timeout-factor"),
             self.boundless_order_lock_timeout_factor.to_string(),
-            String::from("--boundless-order-timeout-factor"),
+            String::from("--boundless-order-expiry-factor"),
             self.boundless_order_expiry_factor.to_string(),
             String::from("--boundless-order-check-interval"),
             self.boundless_order_check_interval.to_string(),

--- a/crates/prover/src/backends/boundless.rs
+++ b/crates/prover/src/backends/boundless.rs
@@ -14,24 +14,22 @@
 
 use crate::args::ProvingArgs;
 use crate::ProvingError;
-use alloy::network::Ethereum;
 use alloy::transports::http::reqwest::Url;
-use alloy_primitives::utils::parse_ether;
 use alloy_primitives::{Address, U256};
 use anyhow::{anyhow, bail, Context};
 use boundless_market::alloy::providers::Provider;
 use boundless_market::alloy::signers::local::PrivateKeySigner;
-use boundless_market::client::{Client, ClientBuilder};
-use boundless_market::contracts::{
-    Input, Offer, Predicate, ProofRequest, RequestId, RequestStatus, Requirements,
-};
-use boundless_market::input::InputBuilder;
-use boundless_market::storage::{StorageProvider, StorageProviderConfig, StorageProviderType};
+use boundless_market::client::Client;
+use boundless_market::contracts::{Predicate, RequestId, RequestStatus, Requirements};
+use boundless_market::request_builder::OfferParams;
+use boundless_market::storage::{StorageProviderConfig, StorageProviderType};
+use boundless_market::{Deployment, GuestEnv, StandardStorageProvider};
 use clap::Parser;
 use kailua_build::{KAILUA_FPVM_ELF, KAILUA_FPVM_ID};
 use kailua_common::journal::ProofJournal;
 use risc0_zkvm::sha::Digestible;
 use risc0_zkvm::{default_executor, ExecutorEnv, Journal, Receipt};
+use std::borrow::Cow;
 use std::time::Duration;
 use tracing::info;
 use tracing::log::warn;
@@ -47,62 +45,81 @@ pub struct BoundlessArgs {
 }
 
 #[derive(Parser, Debug, Clone)]
-#[group(requires_all = ["boundless_rpc_url", "boundless_wallet_key", "boundless_set_verifier_address", "boundless_market_address"])]
+#[group(requires_all = ["boundless_rpc_url", "boundless_wallet_key"])]
 pub struct MarketProviderConfig {
     /// URL of the Ethereum RPC endpoint.
-    #[clap(long, env)]
-    #[arg(required = false)]
+    #[clap(long, env, required = false)]
     pub boundless_rpc_url: Url,
     /// Private key used to interact with the EvenNumber contract.
-    #[clap(long, env)]
-    #[arg(required = false)]
+    #[clap(long, env, required = false)]
     pub boundless_wallet_key: PrivateKeySigner,
-    /// Submit the request offchain via the provided order stream service url.
+
+    /// EIP-155 chain ID of the network hosting Boundless.
+    ///
+    /// This parameter takes precedent over all other deployment arguments if set to a known value
+    #[clap(long, env, required = false)]
+    pub boundless_chain_id: Option<u64>,
+    /// Address of the [BoundlessMarket] contract.
+    ///
+    /// [BoundlessMarket]: crate::contracts::IBoundlessMarket
+    #[clap(long, env, required = false)]
+    pub boundless_market_address: Option<Address>,
+    /// Address of the [RiscZeroVerifierRouter] contract.
+    ///
+    /// The verifier router implements [IRiscZeroVerifier]. Each network has a canonical router,
+    /// that is deployed by the core team. You can additionally deploy and manage your own verifier
+    /// instead. See the [Boundless docs for more details].
+    ///
+    /// [RiscZeroVerifierRouter]: https://github.com/risc0/risc0-ethereum/blob/main/contracts/src/RiscZeroVerifierRouter.sol
+    /// [IRiscZeroVerifier]: https://github.com/risc0/risc0-ethereum/blob/main/contracts/src/IRiscZeroVerifier.sol
+    /// [Boundless docs for more details]: https://docs.beboundless.xyz/developers/smart-contracts/verifier-contracts
+    #[clap(
+        long,
+        env = "VERIFIER_ADDRESS",
+        required = false,
+        long_help = "Address of the RiscZeroVerifierRouter contract"
+    )]
+    pub boundless_verifier_router_address: Option<Address>,
+    /// Address of the [RiscZeroSetVerifier] contract.
+    ///
+    /// [RiscZeroSetVerifier]: https://github.com/risc0/risc0-ethereum/blob/main/contracts/src/RiscZeroSetVerifier.sol
+    #[clap(long, env, required = false)]
+    pub boundless_set_verifier_address: Option<Address>,
+    /// Address of the stake token contract. The staking token is an ERC-20.
+    #[clap(long, env, required = false)]
+    pub boundless_stake_token_address: Option<Address>,
+    /// URL for the offchain [order stream service].
+    ///
+    /// [order stream service]: crate::order_stream_client
     #[clap(
         long,
         env,
-        requires = "boundless_order_stream_url",
-        default_value_t = false
+        required = false,
+        long_help = "URL for the offchain order stream service"
     )]
-    pub boundless_offchain: bool,
-    /// Offchain order stream service URL to submit offchain requests to.
-    #[clap(long, env)]
-    pub boundless_order_stream_url: Option<Url>,
-    /// Address of the RiscZeroSetVerifier contract.
-    #[clap(long, env)]
-    #[arg(required = false)]
-    pub boundless_set_verifier_address: Address,
-    /// Address of the BoundlessMarket contract.
-    #[clap(long, env)]
-    #[arg(required = false)]
-    pub boundless_market_address: Address,
+    pub boundless_order_stream_url: Option<Cow<'static, str>>,
+
     /// Number of transactions to lookback at
-    #[clap(long, env)]
-    #[arg(required = false, default_value_t = 5)]
+    #[clap(long, env, required = false, default_value_t = 5)]
     pub boundless_lookback: u32,
-    /// Starting price per megacycle of the proving order
-    #[clap(long, env)]
-    #[arg(required = false, default_value = "0.0001")]
-    pub boundless_order_min_price_eth: String,
-    /// Maximum price per megacycle of the proving order
-    #[clap(long, env)]
-    #[arg(required = false, default_value = "0.0002")]
-    pub boundless_order_max_price_eth: String,
-    /// Time in seconds before order pricing increases
-    #[clap(long, env)]
-    #[arg(required = false, default_value_t = 60)]
+
+    /// Starting price (wei) per cycle of the proving order
+    #[clap(long, env, required = false, default_value = "100000000")]
+    pub boundless_cycle_min_wei: U256,
+    /// Maximum price (wei) per cycle of the proving order
+    #[clap(long, env, required = false, default_value = "200000000")]
+    pub boundless_cycle_max_wei: U256,
+    /// Duration in seconds for the price to ramp up from min to max.
+    #[clap(long, env, required = false, default_value_t = 60)]
     pub boundless_order_ramp_up_period: u32,
-    /// Multiplier for order fulfillment timeout after locking
-    #[clap(long, env)]
-    #[arg(required = false, default_value_t = 3.0)]
+    /// Multiplier for order fulfillment timeout (seconds/segment) after locking
+    #[clap(long, env, required = false, default_value_t = 3.0)]
     pub boundless_order_lock_timeout_factor: f64,
-    /// Multiplier for order expiry timeout after creation
-    #[clap(long, env)]
-    #[arg(required = false, default_value_t = 10.0)]
+    /// Multiplier for order expiry timeout (seconds/segment) after creation
+    #[clap(long, env, required = false, default_value_t = 10.0)]
     pub boundless_order_timeout_factor: f64,
     /// Time in seconds between attempts to check order status
-    #[clap(long, env)]
-    #[arg(required = false, default_value_t = 12)]
+    #[clap(long, env, required = false, default_value_t = 12)]
     pub boundless_order_check_interval: u64,
 }
 
@@ -111,22 +128,58 @@ impl MarketProviderConfig {
         &self,
         storage_provider_config: &Option<StorageProviderConfig>,
     ) -> Vec<String> {
-        let mut proving_args = Vec::new();
-        proving_args.extend(vec![
+        // RPC/Wallet args
+        let mut proving_args = vec![
             String::from("--boundless-rpc-url"),
             self.boundless_rpc_url.to_string(),
             String::from("--boundless-wallet-key"),
             self.boundless_wallet_key.to_bytes().to_string(),
-            String::from("--boundless-set-verifier-address"),
-            self.boundless_set_verifier_address.to_string(),
-            String::from("--boundless-market-address"),
-            self.boundless_market_address.to_string(),
+        ];
+        // Boundless Deployment args
+        if let Some(boundless_chain_id) = self.boundless_chain_id {
+            proving_args.extend(vec![
+                String::from("--boundless-chain-id"),
+                boundless_chain_id.to_string(),
+            ]);
+        };
+        if let Some(boundless_market_address) = &self.boundless_market_address {
+            proving_args.extend(vec![
+                String::from("--boundless-market-address"),
+                boundless_market_address.to_string(),
+            ]);
+        };
+        if let Some(boundless_verifier_router_address) = &self.boundless_verifier_router_address {
+            proving_args.extend(vec![
+                String::from("--boundless-verifier-router-address"),
+                boundless_verifier_router_address.to_string(),
+            ]);
+        };
+        if let Some(boundless_set_verifier_address) = &self.boundless_set_verifier_address {
+            proving_args.extend(vec![
+                String::from("--boundless-set-verifier-address"),
+                boundless_set_verifier_address.to_string(),
+            ]);
+        };
+        if let Some(boundless_stake_token_address) = &self.boundless_stake_token_address {
+            proving_args.extend(vec![
+                String::from("--boundless-stake-token-address"),
+                boundless_stake_token_address.to_string(),
+            ]);
+        };
+        if let Some(boundless_order_stream_url) = &self.boundless_order_stream_url {
+            proving_args.extend(vec![
+                String::from("--boundless-order-stream-url"),
+                boundless_order_stream_url.to_string(),
+            ]);
+        };
+        // Proving fee args
+        proving_args.extend(vec![
             String::from("--boundless-lookback"),
             self.boundless_lookback.to_string(),
-            String::from("--boundless-order-min-price-eth"),
-            self.boundless_order_min_price_eth.to_string(),
-            String::from("--boundless-order-max-price-eth"),
-            self.boundless_order_max_price_eth.to_string(),
+            String::from("--boundless-cycle-min wei"),
+            self.boundless_cycle_min_wei.to_string(),
+            String::from("--boundless-cycle-max-wei"),
+            self.boundless_cycle_max_wei.to_string(),
             String::from("--boundless-order-ramp-up-period"),
             self.boundless_order_ramp_up_period.to_string(),
             String::from("--boundless-order-lock-timeout-factor"),
@@ -136,15 +189,7 @@ impl MarketProviderConfig {
             String::from("--boundless-order-check-interval"),
             self.boundless_order_check_interval.to_string(),
         ]);
-        if self.boundless_offchain {
-            proving_args.push(String::from("--boundless-offchain"));
-        }
-        if let Some(url) = &self.boundless_order_stream_url {
-            proving_args.extend(vec![
-                String::from("--boundless-order-stream-url"),
-                url.to_string(),
-            ]);
-        }
+        // Storage provider args
         if let Some(storage_cfg) = storage_provider_config {
             match &storage_cfg.storage_provider {
                 StorageProviderType::S3 => {
@@ -203,8 +248,8 @@ impl MarketProviderConfig {
 }
 
 pub async fn run_boundless_client(
-    args: MarketProviderConfig,
-    storage: Option<StorageProviderConfig>,
+    market: MarketProviderConfig,
+    storage: StorageProviderConfig,
     journal: ProofJournal,
     witness_frames: Vec<Vec<u8>>,
     stitched_proofs: Vec<Receipt>,
@@ -214,20 +259,48 @@ pub async fn run_boundless_client(
     info!("Running boundless client.");
     let proof_journal = Journal::new(journal.encode_packed());
 
+    // Instantiate storage provider
+    let storage_provider = StandardStorageProvider::from_config(&storage)
+        .map_err(|e| ProvingError::OtherError(anyhow!(e)))?;
+
+    // Override deployment configuration if set
+    let market_deployment = market
+        .boundless_chain_id
+        .and_then(Deployment::from_chain_id)
+        .or_else(|| {
+            let mut builder = Deployment::builder();
+            if let Some(boundless_market_address) = market.boundless_market_address {
+                builder.boundless_market_address(boundless_market_address);
+            };
+            if let Some(boundless_verifier_router_address) =
+                market.boundless_verifier_router_address
+            {
+                builder.verifier_router_address(boundless_verifier_router_address);
+            };
+            if let Some(boundless_set_verifier_address) = market.boundless_set_verifier_address {
+                builder.set_verifier_address(boundless_set_verifier_address);
+            };
+            if let Some(boundless_stake_token_address) = market.boundless_stake_token_address {
+                builder.stake_token_address(boundless_stake_token_address);
+            };
+            if let Some(boundless_order_stream_url) = market.boundless_order_stream_url.clone() {
+                builder.order_stream_url(boundless_order_stream_url);
+            };
+            builder.build().ok()
+        });
+
     // Instantiate client
-    let boundless_client = ClientBuilder::default()
-        .with_private_key(args.boundless_wallet_key)
-        .with_rpc_url(args.boundless_rpc_url)
-        .with_boundless_market_address(args.boundless_market_address)
-        .with_set_verifier_address(args.boundless_set_verifier_address)
-        .with_storage_provider_config(storage)
-        .await
-        .map_err(|e| ProvingError::OtherError(anyhow!(e)))?
-        .with_order_stream_url(
-            args.boundless_offchain
-                .then_some(args.boundless_order_stream_url)
-                .flatten(),
-        )
+    let boundless_client = Client::builder()
+        .with_private_key(market.boundless_wallet_key)
+        .with_rpc_url(market.boundless_rpc_url)
+        .with_deployment(market_deployment)
+        .with_storage_provider(Some(storage_provider))
+        .config_offer_layer(|config| {
+            config
+                .min_price_per_cycle(market.boundless_cycle_min_wei)
+                .max_price_per_cycle(market.boundless_cycle_max_wei)
+                .ramp_up_period(market.boundless_order_ramp_up_period)
+        })
         .build()
         .await
         .map_err(|e| ProvingError::OtherError(anyhow!(e)))?;
@@ -240,7 +313,7 @@ pub async fn run_boundless_client(
     .with_groth16_proof();
 
     // Check if an unexpired request had already been made recently
-    let boundless_wallet_address = boundless_client.local_signer.as_ref().unwrap().address();
+    let boundless_wallet_address = boundless_client.signer.as_ref().unwrap().address();
     let boundless_wallet_nonce = boundless_client
         .provider()
         .get_transaction_count(boundless_wallet_address)
@@ -249,7 +322,7 @@ pub async fn run_boundless_client(
         .map_err(|e| ProvingError::OtherError(anyhow!(e)))? as u32;
 
     // Look back at prior transactions to avoid repeated requests
-    for i in 0..args.boundless_lookback {
+    for i in 0..market.boundless_lookback {
         if i > boundless_wallet_nonce {
             break;
         }
@@ -295,7 +368,7 @@ pub async fn run_boundless_client(
         return retrieve_proof(
             boundless_client,
             request_id,
-            args.boundless_order_check_interval,
+            market.boundless_order_check_interval,
             request.expires_at(),
         )
         .await
@@ -326,85 +399,60 @@ pub async fn run_boundless_client(
     .await
     .map_err(|e| ProvingError::OtherError(anyhow!(e)))?
     .map_err(|e| ProvingError::ExecutionError(anyhow!(e)))?;
-    let mcycles_count = session_info
+    let cycle_count = session_info
         .segments
         .iter()
         .map(|segment| 1 << segment.po2)
-        .sum::<u64>()
-        .div_ceil(1_000_000);
+        .sum::<u64>();
 
-    // todo: remember this storage location to avoid duplicate uploads
-    // Upload the ELF to the storage provider so that it can be fetched by the market.
-    if boundless_client.storage_provider.is_none() {
-        return Err(ProvingError::OtherError(anyhow!(
-            "A storage provider is required to host the FPVM program and input."
-        )));
-    }
-    let image_url = boundless_client
-        .upload_program(KAILUA_FPVM_ELF)
-        .await
-        .map_err(|e| ProvingError::OtherError(anyhow!(e)))?;
-    info!("Uploaded image to {}", image_url);
     // Upload input
-    let mut builder = InputBuilder::new();
+    let mut guest_env_builder = GuestEnv::builder();
     for frame in &witness_frames {
-        builder = builder.write_frame(frame);
+        guest_env_builder = guest_env_builder.write_frame(frame);
     }
     // Pass in proofs
     for proof in &stitched_proofs {
-        builder = builder
+        guest_env_builder = guest_env_builder
             .write(proof)
             .map_err(|e| ProvingError::OtherError(anyhow!(e)))?;
     }
-    // Build final input
-    let input = builder
+    // Build input vector
+    let input = guest_env_builder
         .build_vec()
         .map_err(|e| ProvingError::OtherError(anyhow!(e)))?;
-    let input_url = boundless_client
-        .upload_input(&input)
-        .await
-        .map_err(|e| ProvingError::OtherError(anyhow!(e)))?;
-    info!("Uploaded input to {input_url}");
-    let request_input = Input::url(input_url);
-    let request = ProofRequest::builder()
-        .with_image_url(image_url.as_str())
-        .with_input(request_input)
+
+    // Build final request
+    let mc_segments = cycle_count.div_ceil(1 << 20) as f64;
+    let request = boundless_client
+        .new_request()
+        .with_program(KAILUA_FPVM_ELF)
+        .with_stdin(input)
         .with_requirements(requirements)
         .with_offer(
-            Offer::default()
-                .with_min_price_per_mcycle(
-                    parse_ether(&args.boundless_order_min_price_eth)
-                        .map_err(|e| ProvingError::OtherError(anyhow!(e)))?,
-                    mcycles_count,
-                )
-                .with_max_price_per_mcycle(
-                    parse_ether(&args.boundless_order_max_price_eth)
-                        .map_err(|e| ProvingError::OtherError(anyhow!(e)))?,
-                    mcycles_count,
-                )
-                .with_ramp_up_period(args.boundless_order_ramp_up_period)
-                .with_lock_stake_per_mcycle(
-                    parse_ether(&args.boundless_order_max_price_eth)
-                        .map_err(|e| ProvingError::OtherError(anyhow!(e)))?,
-                    mcycles_count,
-                )
-                .with_lock_timeout(
-                    (args.boundless_order_lock_timeout_factor * mcycles_count as f64) as u32,
-                )
-                .with_timeout((args.boundless_order_timeout_factor * mcycles_count as f64) as u32),
+            OfferParams::builder()
+                .lock_stake(market.boundless_cycle_max_wei * U256::from(cycle_count))
+                .lock_timeout((market.boundless_order_lock_timeout_factor * mc_segments) as u32)
+                .timeout((market.boundless_order_timeout_factor * mc_segments) as u32)
+                .build()
+                .map_err(|e| ProvingError::OtherError(anyhow!(e)))?,
         )
         .with_request_id(RequestId::new(
             boundless_wallet_address,
             boundless_wallet_nonce,
-        ))
-        .build()
-        .map_err(|e| ProvingError::OtherError(anyhow!(e)))?;
+        ));
 
     // Send the request and wait for it to be completed.
-    let (request_id, expires_at) = boundless_client
-        .submit_request(&request)
-        .await
-        .map_err(|e| ProvingError::OtherError(anyhow!(e)))?;
+    let (request_id, expires_at) = if market.boundless_order_stream_url.is_some() {
+        boundless_client
+            .submit_offchain(request)
+            .await
+            .map_err(|e| ProvingError::OtherError(anyhow!(e)))?
+    } else {
+        boundless_client
+            .submit_onchain(request)
+            .await
+            .map_err(|e| ProvingError::OtherError(anyhow!(e)))?
+    };
     info!("Boundless request 0x{request_id:x} submitted");
 
     if skip_await_proof {
@@ -415,15 +463,15 @@ pub async fn run_boundless_client(
     retrieve_proof(
         boundless_client,
         request_id,
-        args.boundless_order_check_interval,
+        market.boundless_order_check_interval,
         expires_at,
     )
     .await
     .map_err(|e| ProvingError::OtherError(anyhow!(e)))
 }
 
-pub async fn retrieve_proof<P: Provider<Ethereum> + 'static + Clone, S: StorageProvider>(
-    boundless_client: Client<P, S>,
+pub async fn retrieve_proof(
+    boundless_client: Client,
     request_id: U256,
     interval: u64,
     expires_at: u64,

--- a/crates/prover/src/client/proving.rs
+++ b/crates/prover/src/client/proving.rs
@@ -186,11 +186,11 @@ pub async fn seek_fpvm_proof(
     skip_await_proof: bool,
 ) -> Result<(), ProvingError> {
     // compute the zkvm proof
-    let proof = match boundless.market {
-        Some(marked_provider_config) if !is_dev_mode() => {
+    let proof = match (boundless.market, boundless.storage) {
+        (Some(marked_provider_config), Some(storage_provider_config)) if !is_dev_mode() => {
             run_boundless_client(
                 marked_provider_config,
-                boundless.storage,
+                storage_provider_config,
                 proof_journal,
                 witness_frames,
                 stitched_proofs,

--- a/crates/prover/src/client/proving.rs
+++ b/crates/prover/src/client/proving.rs
@@ -31,6 +31,7 @@ use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use kona_proof::l1::OracleBlobProvider;
 use kona_proof::CachingOracle;
 use risc0_zkvm::{is_dev_mode, Receipt};
+use serde::Serialize;
 use std::fmt::Debug;
 use std::sync::Arc;
 use tokio::fs::File;
@@ -221,25 +222,25 @@ pub async fn seek_fpvm_proof(
     };
 
     // Save proof file to disk
-    save_proof_to_disk(&proof).await;
+    let proof_journal = ProofJournal::decode_packed(proof.journal.as_ref());
+    save_to_bincoded_file(&proof, &proof_file_name(&proof_journal))
+        .await
+        .context("save_to_bincoded_file")
+        .map_err(ProvingError::OtherError)?;
 
     Ok(())
 }
 
-pub async fn save_proof_to_disk(proof: &Receipt) {
-    // Save proof file to disk
-    let proof_journal = ProofJournal::decode_packed(proof.journal.as_ref());
-    let mut output_file = File::create(proof_file_name(&proof_journal))
+pub async fn save_to_bincoded_file<T: Serialize>(value: &T, file_name: &str) -> anyhow::Result<()> {
+    let mut file = File::create(file_name)
         .await
-        .expect("Failed to create proof output file");
-    // Write proof data to file
-    let proof_bytes = bincode::serialize(proof).expect("Could not serialize proof.");
-    output_file
-        .write_all(proof_bytes.as_slice())
+        .context("Failed to create output file.")?;
+    let data = bincode::serialize(value).context("Could not serialize proving data.")?;
+    file.write_all(data.as_slice())
         .await
-        .expect("Failed to write proof to file");
-    output_file
-        .flush()
+        .context("Failed to write proof to file")?;
+    file.flush()
         .await
-        .expect("Failed to flush proof output file data.");
+        .context("Failed to flush proof output file data.")?;
+    Ok(())
 }

--- a/crates/prover/src/tasks.rs
+++ b/crates/prover/src/tasks.rs
@@ -14,7 +14,7 @@
 
 use crate::args::ProveArgs;
 use crate::kv::RWLKeyValueStore;
-use crate::proof::{proof_file_name, read_proof_file};
+use crate::proof::{proof_file_name, read_bincoded_file};
 use crate::ProvingError;
 use alloy_primitives::B256;
 use anyhow::{anyhow, Context};
@@ -531,7 +531,7 @@ pub async fn compute_cached_proof(
         .await?;
     }
 
-    read_proof_file(&proof_file_name)
+    read_bincoded_file(&proof_file_name)
         .await
         .context(format!(
             "Failed to read proof file {proof_file_name} contents."

--- a/crates/validator/src/tasks.rs
+++ b/crates/validator/src/tasks.rs
@@ -16,7 +16,7 @@ use crate::channel::Message;
 use anyhow::Context;
 use kailua_prover::args::ProveArgs;
 use kailua_prover::channel::AsyncChannel;
-use kailua_prover::proof::read_proof_file;
+use kailua_prover::proof::read_bincoded_file;
 use kailua_prover::prove::prove;
 use kailua_sync::await_tel_res;
 use opentelemetry::global::tracer;
@@ -107,7 +107,7 @@ pub async fn handle_proving_tasks(
 
         // wait for io then read computed proof from disk
         sleep(Duration::from_secs(1)).await;
-        match read_proof_file(&proof_file_name).await {
+        match read_bincoded_file(&proof_file_name).await {
             Ok(proof) => {
                 // Send proof via the channel
                 proof_sender


### PR DESCRIPTION
This brings Boundless support up to date with the latest crate and adds preflight caching to speed up recovery on error.