### PR TITLE
WIP: Lightweight Bridge Client

### DIFF
--- a/bin/cli/src/lib.rs
+++ b/bin/cli/src/lib.rs
@@ -21,6 +21,7 @@ pub mod config;
 pub mod demo;
 pub mod fast_track;
 pub mod fault;
+pub mod track;
 
 #[derive(clap::Parser, Debug, Clone)]
 #[command(name = "kailua-cli")]
@@ -76,6 +77,12 @@ pub enum KailuaCli {
         #[clap(flatten)]
         cli: CliArgs,
     },
+    Track {
+        #[clap(flatten)]
+        args: track::TrackArgs,
+        #[clap(flatten)]
+        cli: CliArgs,
+    },
 }
 
 #[derive(clap::Args, Debug, Clone)]
@@ -95,6 +102,7 @@ impl KailuaCli {
             KailuaCli::TestFault { cli, .. } => cli.v,
             KailuaCli::Benchmark { cli, .. } => cli.v,
             KailuaCli::Demo { cli, .. } => cli.v,
+            KailuaCli::Track { cli, .. } => cli.v,
         }
     }
 
@@ -104,6 +112,7 @@ impl KailuaCli {
             KailuaCli::Validate { args, .. } => args.sync.data_dir.clone(),
             KailuaCli::Prove { args, .. } => args.kona.data_dir.clone(),
             KailuaCli::Demo { args, .. } => args.data_dir.clone(),
+            KailuaCli::Track { args, .. } => args.sync.data_dir.clone(),
             _ => None,
         }
     }
@@ -118,6 +127,7 @@ impl KailuaCli {
             KailuaCli::TestFault { args, .. } => &args.propose_args.sync.telemetry,
             KailuaCli::Benchmark { args, .. } => &args.sync.telemetry,
             KailuaCli::Demo { args, .. } => &args.telemetry,
+            KailuaCli::Track { args, .. } => &args.sync.telemetry,
         }
     }
 }

--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -68,6 +68,9 @@ async fn main() -> anyhow::Result<()> {
         KailuaCli::Demo { args, cli } => {
             await_tel!(context, kailua_cli::demo::demo(args, cli.v, data_dir))
         }
+        KailuaCli::Track { args, .. } => {
+            await_tel!(context, kailua_cli::track::track(args, data_dir))
+        }
     };
 
     let span = context.span();

--- a/bin/cli/src/track.rs
+++ b/bin/cli/src/track.rs
@@ -1,0 +1,131 @@
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::Context;
+use kailua_contracts::*;
+use kailua_sync::agent::{SyncAgent, FINAL_L2_BLOCK_RESOLVED};
+use kailua_sync::args::SyncArgs;
+use kailua_sync::stall::Stall;
+use kailua_sync::{await_tel, KAILUA_GAME_TYPE};
+use opentelemetry::global::tracer;
+use opentelemetry::trace::FutureExt;
+use opentelemetry::trace::{TraceContextExt, Tracer};
+use std::path::PathBuf;
+use std::time::Duration;
+use tokio::time::sleep;
+use tracing::{error, info, warn};
+
+#[derive(clap::Args, Debug, Clone)]
+pub struct TrackArgs {
+    #[clap(flatten)]
+    pub sync: SyncArgs,
+    /// Whether to bypass loading rollup chain configurations from the kona registry
+    #[clap(long, env, default_value_t = false)]
+    pub bypass_chain_registry: bool,
+}
+
+pub async fn track(args: TrackArgs, data_dir: PathBuf) -> anyhow::Result<()> {
+    let tracer = tracer("kailua");
+    let context = opentelemetry::Context::current_with_span(tracer.start("sync"));
+
+    // todo: auto update deployment
+    // check dgf for set implementation events
+    // order by their game index
+
+    // initialize sync agent
+    let mut agent = SyncAgent::new(
+        &args.sync.provider,
+        data_dir,
+        args.sync.kailua_game_implementation,
+        args.sync.kailua_anchor_address,
+        args.bypass_chain_registry,
+    )
+    .await?;
+    info!("KailuaTreasury({:?})", agent.deployment.treasury);
+
+    // Check if deployment is still valid
+    let dispute_game_factory =
+        IDisputeGameFactory::new(agent.deployment.factory, &agent.provider.l1_provider);
+    let latest_game_impl_addr = dispute_game_factory
+        .gameImpls(KAILUA_GAME_TYPE)
+        .stall_with_context(context.clone(), "DisputeGameFactory::gameImpls")
+        .await;
+    if latest_game_impl_addr != agent.deployment.game {
+        warn!(
+            "Deployment {} outdated. Found new deployment {latest_game_impl_addr}.",
+            agent.deployment.game
+        );
+    }
+
+    loop {
+        // Wait for new data on every iteration
+        sleep(Duration::from_secs(1)).await;
+        // fetch latest games
+        let loaded_proposals = match await_tel!(
+            context,
+            agent.sync(
+                #[cfg(feature = "devnet")]
+                args.sync.delay_l2_blocks,
+                args.sync.final_l2_block
+            )
+        )
+        .context("SyncAgent::sync")
+        {
+            Ok(result) => result,
+            Err(err) => {
+                if err
+                    .root_cause()
+                    .to_string()
+                    .contains(FINAL_L2_BLOCK_RESOLVED)
+                {
+                    warn!("handle_proposals terminated");
+                    return Ok(());
+                }
+                error!("Synchronization error: {err:?}");
+                vec![]
+            }
+        };
+
+        for proposal_index in loaded_proposals {
+            // Load proposal from db
+            let Some(proposal) = agent.proposals.get(&proposal_index) else {
+                error!("Proposal {proposal_index} missing from database.");
+                continue;
+            };
+            // Ignore non-canonical proposals that will never be resolved
+            if !proposal.canonical.unwrap_or_default() {
+                warn!(
+                    "Ignoring non-canonical proposal {proposal_index} at {}",
+                    proposal.contract
+                );
+                continue;
+            }
+            // Check termination condition
+            if let Some(final_l2_block) = args.sync.final_l2_block {
+                if proposal.output_block_number >= final_l2_block {
+                    warn!(
+                        "Dropping proposal {} with output height {} past final l2 block {}.",
+                        proposal.index, proposal.output_block_number, final_l2_block
+                    );
+                    continue;
+                }
+            }
+            // Print proposal index/address/height/output to stdout
+            println!(
+                "TRACKED\t{proposal_index}\t{}\t{}\t{}",
+                proposal.contract, proposal.output_block_number, proposal.output_root
+            );
+        }
+    }
+}

--- a/crates/proposer/src/propose.rs
+++ b/crates/proposer/src/propose.rs
@@ -164,7 +164,7 @@ pub async fn propose(args: ProposeArgs, data_dir: PathBuf) -> anyhow::Result<()>
             .stall_with_context(context.clone(), "DisputeGameFactory::gameImpls")
             .await;
         if latest_game_impl_addr != agent.deployment.game {
-            warn!("Not proposing. Implementation {} outdated. Found new implementation {latest_game_impl_addr}.", agent.deployment.game);
+            warn!("Not proposing. Deployment {} outdated. Found new deployment {latest_game_impl_addr}.", agent.deployment.game);
             continue;
         }
 

--- a/justfile
+++ b/justfile
@@ -115,6 +115,15 @@ demo size l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc data=".localtestdata" targ
           --num-blocks-per-proof {{size}} \
           {{verbosity}}
 
+track l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc data=".localtestdata" target="release" verbosity="":
+    ./target/{{target}}/kailua-cli track \
+          --eth-rpc-url {{l1_rpc}} \
+          --beacon-rpc-url {{l1_beacon_rpc}} \
+          --op-geth-url {{l2_rpc}} \
+          --op-node-url {{rollup_node_rpc}} \
+          --data-dir {{data}} \
+          {{verbosity}}
+
 
 bench l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc data start length range count target="release" verbosity="":
     ./target/{{target}}/kailua-cli benchmark \


### PR DESCRIPTION
Adds a `track` command to allow bridges to track canonical game contracts that can be safely used to initiate withdrawals.