### PR TITLE
feat: Harden delegated proving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5244,6 +5244,8 @@ version = "1.0.2"
 dependencies = [
  "alloy",
  "anyhow",
+ "bincode",
+ "bonsai-sdk",
  "bytemuck",
  "clap",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5364,6 +5364,7 @@ dependencies = [
  "kona-protocol",
  "kona-registry",
  "kona-std-fpvm",
+ "lazy_static",
  "opentelemetry",
  "risc0-ethereum-contracts",
  "risc0-zkvm",

--- a/bin/cli/Cargo.toml
+++ b/bin/cli/Cargo.toml
@@ -12,6 +12,7 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+bincode.workspace = true
 bytemuck.workspace = true
 clap.workspace = true
 hex.workspace = true
@@ -33,6 +34,8 @@ kailua-prover.workspace = true
 kailua-rpc.workspace = true
 kailua-sync.workspace = true
 kailua-validator.workspace = true
+
+bonsai-sdk.workspace = true
 
 kona-cli.workspace = true
 

--- a/bin/cli/src/bonsai.rs
+++ b/bin/cli/src/bonsai.rs
@@ -1,0 +1,114 @@
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::{anyhow, Context};
+use bonsai_sdk::non_blocking::{Client, SessionId};
+use kailua_build::KAILUA_FPVM_ID;
+use kailua_common::journal::ProofJournal;
+use kailua_prover::backends::{KailuaProveInfo, KailuaSessionStats};
+use kailua_prover::client::proving::save_to_bincoded_file;
+use kailua_prover::proof::{proof_file_name, read_bincoded_file};
+use kailua_prover::ProvingError;
+use kailua_sync::telemetry::TelemetryArgs;
+use risc0_zkvm::Receipt;
+use std::time::Duration;
+use tracing::{error, info, warn};
+
+#[derive(clap::Args, Debug, Clone)]
+pub struct BonsaiArgs {
+    #[clap(long, env)]
+    pub session_id: String,
+    #[clap(flatten)]
+    pub telemetry: TelemetryArgs,
+}
+
+pub async fn bonsai(args: BonsaiArgs) -> anyhow::Result<()> {
+    // Instantiate client
+    let client = Client::from_env(risc0_zkvm::VERSION)?;
+    // fetch session
+    let session = SessionId::new(args.session_id);
+    // wait for receipt
+    let kailua_prove_info = loop {
+        let res = session.status(&client).await?;
+
+        if res.status == "RUNNING" {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            warn!("Proof not yet completed: {:?}", res.status);
+            continue;
+        }
+
+        if res.status != "SUCCEEDED" {
+            error!(
+                "Bonsai prover workflow [{}] exited: {} err: {}",
+                session.uuid,
+                res.status,
+                res.error_msg
+                    .unwrap_or("Bonsai workflow missing error_msg".into()),
+            );
+            return Ok(());
+        }
+
+        // Download the receipt, containing the output
+        let receipt_url = res.receipt_url.ok_or(ProvingError::OtherError(anyhow!(
+            "API error, missing receipt on completed session"
+        )))?;
+        info!("Downloading Bonsai receipt from {receipt_url}.");
+
+        let stats = res
+            .stats
+            .context("Missing stats object on Bonsai status res")?;
+        info!(
+            "Bonsai usage: user_cycles: {} total_cycles: {}",
+            stats.cycles, stats.total_cycles
+        );
+
+        let receipt_buf = client.download(&receipt_url).await?;
+        let receipt: Receipt = bincode::deserialize(&receipt_buf)?;
+
+        info!("Verifying receipt received from Bonsai.");
+        receipt.verify(KAILUA_FPVM_ID)?;
+
+        break KailuaProveInfo {
+            receipt,
+            stats: KailuaSessionStats {
+                segments: stats.segments,
+                total_cycles: stats.total_cycles,
+                user_cycles: stats.cycles,
+                // These are currently unavailable from Bonsai
+                paging_cycles: 0,
+                reserved_cycles: 0,
+            },
+        };
+    };
+
+    let proof_journal = ProofJournal::decode_packed(kailua_prove_info.receipt.journal.as_ref());
+    let file_name = proof_file_name(&proof_journal);
+
+    info!("Writing proof to {file_name}.");
+    if let Ok(prior_receipt) = read_bincoded_file::<Receipt>(&file_name).await {
+        if prior_receipt.verify(KAILUA_FPVM_ID).is_ok() {
+            info!("Skipping overwriting valid receipt file.");
+            return Ok(());
+        }
+        info!("Overwriting invalid receipt file.");
+    }
+
+    if let Err(err) = save_to_bincoded_file(&kailua_prove_info.receipt, &file_name).await {
+        error!("Failed to write proof to {file_name}: {err:?}");
+    }
+
+    info!("Proof written to {file_name}.");
+
+    Ok(())
+}

--- a/bin/cli/src/demo.rs
+++ b/bin/cli/src/demo.rs
@@ -92,6 +92,7 @@ pub async fn demo(args: DemoArgs, verbosity: u8, data_dir: PathBuf) -> anyhow::R
             telemetry: args.telemetry,
         },
         kailua_cli: args.kailua_cli,
+        fast_forward_start: 0,
         fast_forward_target: 0,
         num_concurrent_provers: args.num_concurrent_provers,
         enable_experimental_witness_endpoint: args.enable_experimental_witness_endpoint,

--- a/bin/cli/src/demo.rs
+++ b/bin/cli/src/demo.rs
@@ -50,7 +50,8 @@ pub struct DemoArgs {
     #[arg(long, env, default_value_t = false)]
     pub enable_experimental_witness_endpoint: bool,
 
-    /// The L2 block to start proving from. Defaults to latest safe block.
+    /// The L2 block to start proving from.
+    /// Defaults to three times `num_blocks_per_proof` before latest safe block.
     #[clap(long, env)]
     pub starting_block_height: Option<u64>,
     /// The number of L2 blocks to cover per proof
@@ -172,7 +173,7 @@ pub async fn handle_blocks(
         );
         // start from most recent block if unspecified
         if last_proven.is_none() {
-            last_proven = Some(safe_l2_number);
+            last_proven = Some(safe_l2_number.saturating_sub(3 * args.num_blocks_per_proof + 1));
         }
         // queue required proofs
         while last_proven.unwrap() + args.num_blocks_per_proof < safe_l2_number {

--- a/bin/cli/src/demo.rs
+++ b/bin/cli/src/demo.rs
@@ -220,9 +220,7 @@ pub async fn handle_blocks(
                 )
             );
             // request proof
-            n = n.saturating_sub(1u64);
-            if n == 0 {
-                n = args.nth_proof_to_process;
+            if n == args.nth_proof_to_process {
                 channel
                     .sender
                     .send(Message::Proposal {
@@ -239,12 +237,14 @@ pub async fn handle_blocks(
                     "Requested proof for blocks {} to {}. (N={n})",
                     agreed_l2_block_number, claimed_l2_block_number
                 );
+                n = 0;
             } else {
                 info!(
                     "Skipped proof for blocks {} to {}. (N={n})",
                     agreed_l2_block_number, claimed_l2_block_number
                 );
             }
+            n += 1;
             // update state
             last_proven = Some(claimed_l2_block_number);
         }

--- a/bin/cli/src/lib.rs
+++ b/bin/cli/src/lib.rs
@@ -17,6 +17,7 @@ use kailua_validator::args;
 use std::path::PathBuf;
 
 pub mod bench;
+pub mod bonsai;
 pub mod config;
 pub mod demo;
 pub mod fast_track;
@@ -83,6 +84,12 @@ pub enum KailuaCli {
         #[clap(flatten)]
         cli: CliArgs,
     },
+    Bonsai {
+        #[clap(flatten)]
+        args: bonsai::BonsaiArgs,
+        #[clap(flatten)]
+        cli: CliArgs,
+    },
 }
 
 #[derive(clap::Args, Debug, Clone)]
@@ -103,6 +110,7 @@ impl KailuaCli {
             KailuaCli::Benchmark { cli, .. } => cli.v,
             KailuaCli::Demo { cli, .. } => cli.v,
             KailuaCli::Rpc { cli, .. } => cli.v,
+            KailuaCli::Bonsai { cli, .. } => cli.v,
         }
     }
 
@@ -128,6 +136,7 @@ impl KailuaCli {
             KailuaCli::Benchmark { args, .. } => &args.sync.telemetry,
             KailuaCli::Demo { args, .. } => &args.telemetry,
             KailuaCli::Rpc { args, .. } => &args.sync.telemetry,
+            KailuaCli::Bonsai { args, .. } => &args.telemetry,
         }
     }
 }

--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -71,6 +71,9 @@ async fn main() -> anyhow::Result<()> {
         KailuaCli::Rpc { args, .. } => {
             await_tel!(context, kailua_rpc::rpc::rpc(args, data_dir))
         }
+        KailuaCli::Bonsai { args, .. } => {
+            await_tel!(context, kailua_cli::bonsai::bonsai(args))
+        }
     };
 
     let span = context.span();

--- a/bin/cli/tests/devnet.rs
+++ b/bin/cli/tests/devnet.rs
@@ -251,6 +251,7 @@ async fn proposer_validator() {
                 ..sync.clone()
             },
             kailua_cli: None,
+            fast_forward_start: 0,
             fast_forward_target: 0,
             num_concurrent_provers: 1,
             enable_experimental_witness_endpoint: true,
@@ -300,6 +301,7 @@ async fn proposer_validator() {
                 ..sync.clone()
             },
             kailua_cli: None,
+            fast_forward_start: 0,
             fast_forward_target: 90, // run validity proofs until block 90 is finalized
             num_concurrent_provers: 5,
             enable_experimental_witness_endpoint: true,

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -20,6 +20,7 @@ c-kzg.workspace = true
 clap.workspace = true
 hex.workspace = true
 human_bytes.workspace = true
+lazy_static.workspace = true
 rkyv.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/prover/src/args.rs
+++ b/crates/prover/src/args.rs
@@ -47,6 +47,12 @@ pub struct ProvingArgs {
     pub skip_await_proof: bool,
 }
 
+impl ProvingArgs {
+    pub fn skip_stitching(&self) -> bool {
+        self.skip_derivation_proof || self.skip_await_proof
+    }
+}
+
 /// Run the prover to generate an execution/fault/validity proof
 #[derive(Parser, Clone, Debug)]
 pub struct ProveArgs {

--- a/crates/prover/src/backends/bonsai.rs
+++ b/crates/prover/src/backends/bonsai.rs
@@ -12,16 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::backends::{KailuaProveInfo, KailuaSessionStats};
 use crate::ProvingError;
 use anyhow::{anyhow, Context};
-use bonsai_sdk::non_blocking::Client;
+use bonsai_sdk::non_blocking::{Client, SessionId, SnarkId};
+use bonsai_sdk::responses::SessionStats;
 use human_bytes::human_bytes;
 use kailua_build::{KAILUA_FPVM_ELF, KAILUA_FPVM_ID};
+use kailua_sync::{retry_res, retry_res_timeout};
 use risc0_zkvm::serde::to_vec;
 use risc0_zkvm::sha::Digest;
 use risc0_zkvm::{is_dev_mode, InnerReceipt, Receipt};
 use std::time::Duration;
+use tokio::time::sleep;
 use tracing::log::warn;
 use tracing::{error, info};
 
@@ -69,39 +71,9 @@ pub async fn run_bonsai_client(
         }
     }
 
-    // Upload the ELF with the image_id as its key.
-    let elf = KAILUA_FPVM_ELF.to_vec();
-    info!(
-        "Uploading {} Kailua ELF to Bonsai.",
-        human_bytes(elf.len() as f64).to_string()
-    );
-    let image_id_hex = hex::encode(Digest::from(KAILUA_FPVM_ID));
-    loop {
-        let Err(err) = client.upload_img(&image_id_hex, elf.clone()).await else {
-            break;
-        };
-        error!("Failed to upload Kailua ELF to Bonsai: {err:?}");
-    }
-
-    // Upload the input data
-    info!(
-        "Uploading {} input data to Bonsai.",
-        human_bytes(input.len() as f64).to_string()
-    );
-    let input_id = loop {
-        match client.upload_input(input.clone()).await {
-            Ok(result) => break result,
-            Err(err) => error!("Failed to upload input data to Bonsai: {err:?}"),
-        }
-    };
-
-    // Create session on Bonsai
-    info!("Creating Bonsai proving session.");
-    let session = client
-        .create_session_with_limit(image_id_hex, input_id, assumption_receipt_ids, false, None)
-        .await
-        .map_err(|e| ProvingError::OtherError(anyhow!(e)))?;
-    info!("Bonsai proving SessionID: {}", session.uuid);
+    // Create a session on Bonsai
+    let mut stark_session =
+        create_stark_session(&client, input.clone(), assumption_receipt_ids.clone()).await;
 
     if skip_await_proof {
         warn!("Skipping awaiting proof on Bonsai and exiting process.");
@@ -118,125 +90,195 @@ pub async fn run_bonsai_client(
         Duration::from_secs(1)
     };
 
-    let succinct_prove_info = loop {
+    let stark_receipt = loop {
         // The session has already been started in the executor. Poll bonsai to check if
         // the proof request succeeded.
-        let res = session
-            .status(&client)
-            .await
-            .map_err(|e| ProvingError::OtherError(anyhow!(e)))?;
+        let res = retry_res!(stark_session.status(&client).await).await;
 
-        if res.status == "RUNNING" {
-            tokio::time::sleep(polling_interval).await;
-            continue;
-        }
+        match res.status.as_str() {
+            "RUNNING" => tokio::time::sleep(polling_interval).await,
+            "SUCCEEDED" => {
+                // Download the receipt, containing the output
+                let Some(receipt_url) = res.receipt_url else {
+                    error!("API error, missing receipt on completed session");
+                    continue;
+                };
 
-        if res.status == "SUCCEEDED" {
-            // Download the receipt, containing the output
-            let receipt_url = res.receipt_url.ok_or(ProvingError::OtherError(anyhow!(
-                "API error, missing receipt on completed session"
-            )))?;
-            info!("Downloading Bonsai receipt from {receipt_url}.");
+                let stats = res.stats.unwrap_or_else(|| {
+                    error!("Missing stats object on Bonsai response.");
+                    SessionStats {
+                        segments: 0,
+                        total_cycles: 0,
+                        cycles: 0,
+                    }
+                });
 
-            let stats = res
-                .stats
-                .context("Missing stats object on Bonsai status res")
-                .map_err(|e| ProvingError::OtherError(anyhow!(e)))?;
-            info!(
-                "Bonsai usage: user_cycles: {} total_cycles: {}",
-                stats.cycles, stats.total_cycles
-            );
+                info!(
+                    "Bonsai usage: user_cycles: {} total_cycles: {}",
+                    stats.cycles, stats.total_cycles
+                );
 
-            let receipt_buf = client
-                .download(&receipt_url)
-                .await
-                .map_err(|e| ProvingError::OtherError(anyhow!(e)))?;
-            let receipt: Receipt = bincode::deserialize(&receipt_buf)
-                .map_err(|e| ProvingError::OtherError(anyhow!(e)))?;
+                info!("Downloading Bonsai receipt from {receipt_url}.");
+                let Ok(receipt_buf) = client.download(&receipt_url).await else {
+                    error!("Failed to download STARK receipt at {receipt_url}");
+                    continue;
+                };
 
-            info!("Verifying receipt received from Bonsai.");
-            receipt
-                .verify(KAILUA_FPVM_ID)
-                .map_err(|e| ProvingError::OtherError(anyhow!(e)))?;
+                info!("Verifying receipt received from Bonsai.");
+                let Ok(receipt) = bincode::deserialize::<Receipt>(&receipt_buf) else {
+                    error!("Failed to deserialize receipt at {receipt_url}");
+                    continue;
+                };
+                let Ok(()) = receipt.verify(KAILUA_FPVM_ID) else {
+                    error!("Failed to verify receipt at {receipt_url}.");
+                    continue;
+                };
 
-            break KailuaProveInfo {
-                receipt,
-                stats: KailuaSessionStats {
-                    segments: stats.segments,
-                    total_cycles: stats.total_cycles,
-                    user_cycles: stats.cycles,
-                    // These are currently unavailable from Bonsai
-                    paging_cycles: 0,
-                    reserved_cycles: 0,
-                },
-            };
-        } else {
-            return Err(ProvingError::ExecutionError(anyhow!(
-                "Bonsai prover workflow [{}] exited: {} err: {}",
-                session.uuid,
-                res.status,
-                res.error_msg
-                    .unwrap_or("Bonsai workflow missing error_msg".into()),
-            )));
+                break receipt;
+            }
+            _ => {
+                error!(
+                    "Bonsai prover session [{}] exited: {} err: {:?}. Retrying.",
+                    stark_session.uuid, res.status, res.error_msg
+                );
+                // Retry and create another session
+                stark_session =
+                    create_stark_session(&client, input.clone(), assumption_receipt_ids.clone())
+                        .await;
+            }
         }
     };
 
     if !prove_snark {
-        return Ok(succinct_prove_info.receipt);
+        return Ok(stark_receipt);
     }
     info!("Wrapping STARK as SNARK on Bonsai.");
+    let stark_receipt_bincoded =
+        bincode::serialize(&stark_receipt).map_err(|e| ProvingError::OtherError(anyhow!(e)))?;
 
     // Request that Bonsai compress further, to Groth16.
-    let snark_session = client
-        .create_snark(session.uuid)
-        .await
-        .map_err(|e| ProvingError::OtherError(anyhow!(e)))?;
-    let snark_receipt_url = loop {
-        let res = snark_session
-            .status(&client)
-            .await
-            .map_err(|e| ProvingError::OtherError(anyhow!(e)))?;
+    let mut snark_session = create_snark_session(
+        &client,
+        stark_receipt_bincoded.clone(),
+        Some(stark_session.uuid),
+    )
+    .await;
+
+    let groth16_receipt = loop {
+        let res = retry_res!(snark_session.status(&client).await).await;
+
         match res.status.as_str() {
-            "RUNNING" => {
-                std::thread::sleep(polling_interval);
-                continue;
-            }
+            "RUNNING" => sleep(polling_interval).await,
             "SUCCEEDED" => {
-                break res
-                    .output
-                    .with_context(|| {
-                        format!(
-                            "Bonsai prover workflow [{}] reported success, but provided no receipt",
-                            snark_session.uuid
-                        )
-                    })
-                    .map_err(|e| ProvingError::OtherError(anyhow!(e)))?;
+                let Some(receipt_url) = res.output else {
+                    error!("SNARK API error, missing output url.");
+                    continue;
+                };
+
+                info!("Downloading Groth16 receipt from Bonsai.");
+                let Ok(receipt_buf) = client.download(&receipt_url).await else {
+                    error!("Failed to download SNARK receipt at {receipt_url}");
+                    continue;
+                };
+
+                info!("Verifying receipt received from Bonsai.");
+                let Ok(receipt) = bincode::deserialize::<Receipt>(&receipt_buf) else {
+                    error!("Failed to deserialize SNARK receipt at {receipt_url}");
+                    continue;
+                };
+                let Ok(()) = receipt.verify(KAILUA_FPVM_ID) else {
+                    error!("Failed to verify SNARK receipt at {receipt_url}.");
+                    continue;
+                };
+
+                break receipt;
             }
             _ => {
-                return Err(ProvingError::OtherError(anyhow!(
-                    "Bonsai prover workflow [{}] exited: {} err: {}",
-                    snark_session.uuid,
-                    res.status,
-                    res.error_msg
-                        .unwrap_or("Bonsai workflow missing error_msg".into()),
-                )))
+                error!(
+                    "Bonsai prover workflow [{}] exited: {} err: {:?}",
+                    snark_session.uuid, res.status, res.error_msg
+                );
+                snark_session =
+                    create_snark_session(&client, stark_receipt_bincoded.clone(), None).await;
             }
         }
     };
 
-    info!("Downloading Groth16 receipt from Bonsai.");
-    let receipt_buf = client
-        .download(&snark_receipt_url)
-        .await
-        .map_err(|e| ProvingError::OtherError(anyhow!(e)))?;
-    let groth16_receipt: Receipt =
-        bincode::deserialize(&receipt_buf).map_err(|e| ProvingError::OtherError(anyhow!(e)))?;
-    groth16_receipt
-        .verify(KAILUA_FPVM_ID)
-        .context("failed to verify Groth16Receipt returned by Bonsai")
-        .map_err(|e| ProvingError::OtherError(anyhow!(e)))?;
-
     Ok(groth16_receipt)
+}
+
+pub async fn create_snark_session(
+    client: &Client,
+    receipt: Vec<u8>,
+    mut stark_id: Option<String>,
+) -> SnarkId {
+    loop {
+        // Reupload receipt if not first attempt
+        let stark_id = match stark_id.take() {
+            Some(id) => id,
+            None => retry_res!(client.upload_receipt(receipt.clone()).await).await,
+        };
+
+        // Request that Bonsai compress further, to Groth16.
+        if let Ok(result) = client.create_snark(stark_id.clone()).await {
+            break result;
+        }
+    }
+}
+
+pub async fn create_stark_session(
+    client: &Client,
+    input: Vec<u8>,
+    assumption_receipt_ids: Vec<String>,
+) -> SessionId {
+    // Upload the ELF with the image_id as its key.
+    let elf = KAILUA_FPVM_ELF.to_vec();
+    let image_id_hex = hex::encode(Digest::from(KAILUA_FPVM_ID));
+    let is_image_present = retry_res_timeout!(client.has_img(&image_id_hex).await).await;
+    if !is_image_present {
+        info!(
+            "Uploading {} Kailua ELF to Bonsai.",
+            human_bytes(elf.len() as f64)
+        );
+        retry_res!(client.upload_img(&image_id_hex, elf.clone()).await).await;
+    } else {
+        info!("Kailua ELF already exists on Bonsai.");
+    }
+
+    // Retry session creation w/ fresh input each time just in case.
+    loop {
+        // Upload the input data
+        info!(
+            "Uploading {} input data to Bonsai.",
+            human_bytes(input.len() as f64)
+        );
+        let input_id = retry_res!(client.upload_input(input.clone()).await).await;
+
+        // Create session on Bonsai
+        info!("Creating Bonsai proving session.");
+        let session = match client
+            .create_session_with_limit(
+                image_id_hex.clone(),
+                input_id.clone(),
+                assumption_receipt_ids.clone(),
+                false,
+                None,
+            )
+            .await
+        {
+            Ok(session) => session,
+            Err(err) => {
+                error!("Could not create Bonsai session ID: {err:?}");
+                sleep(Duration::from_millis(500)).await;
+                continue;
+            }
+        };
+
+        info!("Bonsai proving SessionID: {}", session.uuid);
+
+        sleep(Duration::from_millis(500)).await;
+        break session;
+    }
 }
 
 pub fn should_use_bonsai() -> bool {

--- a/crates/prover/src/backends/bonsai.rs
+++ b/crates/prover/src/backends/bonsai.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::args::ProvingArgs;
 use crate::ProvingError;
 use anyhow::{anyhow, Context};
 use bonsai_sdk::non_blocking::{Client, SessionId, SnarkId};
@@ -31,7 +32,7 @@ pub async fn run_bonsai_client(
     witness_frames: Vec<Vec<u8>>,
     stitched_proofs: Vec<Receipt>,
     prove_snark: bool,
-    skip_await_proof: bool,
+    proving_args: &ProvingArgs,
 ) -> Result<Receipt, ProvingError> {
     info!("Running Bonsai client.");
     // Instantiate client
@@ -75,9 +76,9 @@ pub async fn run_bonsai_client(
     let mut stark_session =
         create_stark_session(&client, input.clone(), assumption_receipt_ids.clone()).await;
 
-    if skip_await_proof {
-        warn!("Skipping awaiting proof on Bonsai and exiting process.");
-        std::process::exit(0);
+    if proving_args.skip_await_proof {
+        warn!("Skipping awaiting proof on Bonsai.");
+        return Err(ProvingError::NotAwaitingProof);
     }
 
     let polling_interval = if let Ok(ms) = std::env::var("BONSAI_POLL_INTERVAL_MS") {

--- a/crates/prover/src/backends/boundless.rs
+++ b/crates/prover/src/backends/boundless.rs
@@ -522,7 +522,7 @@ pub async fn request_proof(
         .await
         .context("get_transaction_count boundless_wallet_address"))
     .await as u32;
-    let segment_count = cycle_count.div_ceil(1 << 20) as f64;
+    let segment_count = cycle_count.div_ceil(1_000_000) as f64;
     let cycles = U256::from(cycle_count);
     let min_price = market.boundless_cycle_min_wei * cycles;
     let max_price = market.boundless_cycle_max_wei * cycles;
@@ -544,9 +544,7 @@ pub async fn request_proof(
             OfferParams::builder()
                 .min_price(min_price)
                 .max_price(max_price)
-                .lock_stake(U256::from(
-                    market.boundless_mega_cycle_stake * U256::from(segment_count),
-                ))
+                .lock_stake(market.boundless_mega_cycle_stake * U256::from(segment_count))
                 .ramp_up_period((market.boundless_order_ramp_up_factor * segment_count) as u32)
                 .lock_timeout((lock_timeout_factor * segment_count) as u32)
                 .timeout((expiry_factor * segment_count) as u32)

--- a/crates/prover/src/backends/zkvm.rs
+++ b/crates/prover/src/backends/zkvm.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::args::ProvingArgs;
 use crate::backends::{KailuaProveInfo, KailuaSessionStats};
 use crate::ProvingError;
 use anyhow::{anyhow, Context};
@@ -24,9 +25,15 @@ pub async fn run_zkvm_client(
     witness_frames: Vec<Vec<u8>>,
     stitched_proofs: Vec<Receipt>,
     prove_snark: bool,
-    segment_limit: u32,
+    proving_args: &ProvingArgs,
 ) -> Result<Receipt, ProvingError> {
     info!("Running zkvm client.");
+    if proving_args.skip_await_proof {
+        warn!("Skipping awaiting proof locally.");
+        return Err(ProvingError::NotAwaitingProof);
+    }
+
+    let segment_limit = proving_args.segment_limit;
     let prove_info = tokio::task::spawn_blocking(move || {
         let env = build_zkvm_env(witness_frames, stitched_proofs, segment_limit)?;
         let prover = default_prover();

--- a/crates/prover/src/backends/zkvm.rs
+++ b/crates/prover/src/backends/zkvm.rs
@@ -103,5 +103,6 @@ pub fn build_zkvm_env<'a>(
             builder.add_assumption(receipt);
         }
     }
+
     builder.build()
 }

--- a/crates/prover/src/client/payload.rs
+++ b/crates/prover/src/client/payload.rs
@@ -19,6 +19,7 @@ use alloy::providers::{Provider, RootProvider};
 use alloy_primitives::hex::FromHex;
 use alloy_primitives::keccak256;
 use anyhow::{anyhow, Context};
+use human_bytes::human_bytes;
 use kailua_sync::provider::optimism::OpNodeProvider;
 use kailua_sync::{await_tel, retry_res_ctx_timeout};
 use kona_host::KeyValueStore;
@@ -31,12 +32,13 @@ use std::error::Error;
 use std::ops::DerefMut;
 use tracing::{error, info};
 
+/// Returns true iff preflight using `debug_executionWitness` was successful.
 pub async fn run_payload_client(
     mut boot_info: BootInfo,
     l2_provider: RootProvider,
     op_node_provider: OpNodeProvider,
     disk_kv_store: Option<RWLKeyValueStore>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<bool> {
     let tracer = tracer("kailua");
     let context = opentelemetry::Context::current_with_span(tracer.start("run_payload_client"));
 
@@ -109,45 +111,47 @@ pub async fn run_payload_client(
                 "Failed to fetch payload for {} (Skip).",
                 boot_info.claimed_l2_block_number + 1
             );
-            continue;
+            return Ok(false);
         };
 
         // dump preimages into kv store
         let mut kv_lock = kv.write().await;
-        dump_payload_to_kv_store(&execution_witness, kv_lock.deref_mut());
+        let payload_size = dump_payload_to_kv_store(&execution_witness, kv_lock.deref_mut());
         // Mark block payload as processed in kv store
         kv_lock.set(exec_wit_key.into(), vec![])?;
         info!(
-            "Fetched payload for {}.",
+            "Saved {} payload for {}.",
+            human_bytes(payload_size as f64),
             boot_info.claimed_l2_block_number + 1
         );
         drop(kv_lock);
     }
 
-    Ok(())
+    Ok(true)
 }
 
-fn dump_payload_to_kv_store(payload: &serde_json::Value, kv: &mut dyn KeyValueStore) {
+fn dump_payload_to_kv_store(payload: &serde_json::Value, kv: &mut dyn KeyValueStore) -> u64 {
     if let Some(obj) = payload.as_object() {
-        for (k, v) in obj {
-            save_hex_preimage_to_kv(k, kv);
-            dump_payload_to_kv_store(v, kv);
-        }
-    }
-    if let Some(seq) = payload.as_array() {
-        for v in seq {
-            dump_payload_to_kv_store(v, kv);
-        }
-    }
-    if let Some(v) = payload.as_str() {
-        save_hex_preimage_to_kv(v, kv);
+        obj.iter()
+            .map(|(k, v)| save_hex_preimage_to_kv(k, kv) + dump_payload_to_kv_store(v, kv))
+            .sum()
+    } else if let Some(seq) = payload.as_array() {
+        seq.iter().map(|v| dump_payload_to_kv_store(v, kv)).sum()
+    } else if let Some(v) = payload.as_str() {
+        save_hex_preimage_to_kv(v, kv)
+    } else {
+        0
     }
 }
 
-fn save_hex_preimage_to_kv(preimage: &str, kv: &mut dyn KeyValueStore) {
-    if let Ok(preimage) = alloy_primitives::Bytes::from_hex(preimage) {
-        let computed_hash = keccak256(preimage.as_ref());
-        let key = PreimageKey::new_keccak256(*computed_hash);
-        kv.set(key.into(), preimage.into()).unwrap();
-    }
+fn save_hex_preimage_to_kv(preimage: &str, kv: &mut dyn KeyValueStore) -> u64 {
+    alloy_primitives::Bytes::from_hex(preimage)
+        .map(|preimage| {
+            let computed_hash = keccak256(preimage.as_ref());
+            let key = PreimageKey::new_keccak256(*computed_hash);
+            let size = preimage.len() as u64;
+            kv.set(key.into(), preimage.into()).unwrap();
+            size
+        })
+        .unwrap_or(0)
 }

--- a/crates/prover/src/client/payload.rs
+++ b/crates/prover/src/client/payload.rs
@@ -43,6 +43,12 @@ pub async fn run_payload_client(
     let kv = create_split_kv_store(&Default::default(), disk_kv_store)
         .map_err(|e| ProvingError::OtherError(anyhow!(e)))?;
 
+    /* todo:
+       1. Test endpoint success/failure automatically
+       2. abort any attempt to use executionWitness endpoint if failure confirmed
+
+    */
+
     while boot_info.claimed_l2_output_root != boot_info.agreed_l2_output_root {
         // Read block hash
         let block_hash = await_tel!(

--- a/crates/prover/src/client/proving.rs
+++ b/crates/prover/src/client/proving.rs
@@ -209,21 +209,9 @@ pub async fn seek_fpvm_proof(
         }
         _ => {
             if should_use_bonsai() {
-                run_bonsai_client(
-                    witness_frames,
-                    stitched_proofs,
-                    prove_snark,
-                    proving.skip_await_proof,
-                )
-                .await?
+                run_bonsai_client(witness_frames, stitched_proofs, prove_snark, proving).await?
             } else {
-                run_zkvm_client(
-                    witness_frames,
-                    stitched_proofs,
-                    prove_snark,
-                    proving.segment_limit,
-                )
-                .await?
+                run_zkvm_client(witness_frames, stitched_proofs, prove_snark, proving).await?
             }
         }
     };

--- a/crates/prover/src/lib.rs
+++ b/crates/prover/src/lib.rs
@@ -33,6 +33,9 @@ pub enum ProvingError {
     #[error("NotSeekingProof error: witness {0}")]
     NotSeekingProof(usize, Vec<Vec<Execution>>),
 
+    #[error("NotAwaitingProof error")]
+    NotAwaitingProof,
+
     #[error("WitnessSizeError error: size {0} limit {0}")]
     WitnessSizeError(usize, usize, Vec<Vec<Execution>>),
 

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -233,6 +233,7 @@ pub async fn prove(mut args: ProveArgs) -> anyhow::Result<()> {
                         {
                             // we use this special exit code to signal an insufficient l1 head
                             error!("Insufficient L1 head.");
+                            // todo: revisit
                             std::process::exit(111);
                         }
                         bail!("Irrecoverable proving error: {e:?}")

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -192,34 +192,38 @@ pub async fn prove(mut args: ProveArgs) -> anyhow::Result<()> {
             .await
             .expect("Failed to recv prover task");
         let num_blocks = job_args.kona.claimed_l2_block_number - starting_block;
+        let last_block = job_args.kona.claimed_l2_block_number;
 
         match result {
             Ok(proof) => {
-                if let Some(proof) = proof {
+                let cached = Cached {
+                    // used for sorting
+                    args: job_args.clone(),
+                    // all unused
+                    rollup_config: rollup_config.clone(),
+                    disk_kv_store: disk_kv_store.clone(),
+                    precondition_hash,
+                    precondition_validation_data_hash,
+                    stitched_executions: vec![],
+                    stitched_boot_info: vec![],
+                    stitched_proofs: vec![],
+                    prove_snark: false,
+                    force_attempt,
+                    seek_proof: true,
+                };
+                if proof.is_some() {
                     info!(
-                        "Successfully proved {} blocks ({starting_block}..{})",
-                        job_args.kona.claimed_l2_block_number - starting_block,
-                        job_args.kona.claimed_l2_block_number
+                        "Successfully proved {num_blocks} blocks ({starting_block}..{last_block})",
                     );
-                    result_pq.push(OneshotResult {
-                        cached: Cached {
-                            // used for sorting
-                            args: job_args,
-                            // all unused
-                            rollup_config: rollup_config.clone(),
-                            disk_kv_store: disk_kv_store.clone(),
-                            precondition_hash,
-                            precondition_validation_data_hash,
-                            stitched_executions: vec![],
-                            stitched_boot_info: vec![],
-                            stitched_proofs: vec![],
-                            prove_snark: false,
-                            force_attempt,
-                            seek_proof: true,
-                        },
-                        result: Ok(proof),
-                    });
+                } else {
+                    error!(
+                        "Failed to create complete proof for {num_blocks} blocks ({starting_block}..{last_block})",
+                    );
                 }
+                let result = proof
+                    .ok_or_else(|| ProvingError::OtherError(anyhow!("Missing complete proof.")));
+                // enqueue result to reach the termination condition
+                result_pq.push(OneshotResult { cached, result });
             }
             Err(err) => {
                 // Handle error case
@@ -258,7 +262,17 @@ pub async fn prove(mut args: ProveArgs) -> anyhow::Result<()> {
                         unreachable!("NotSeekingProof bubbled up")
                     }
                     ProvingError::DerivationProofError(proofs) => {
-                        info!("Computed {proofs} execution-only proofs.");
+                        info!(
+                            "Successfully proved execution-only for {num_blocks} blocks ({starting_block}..{last_block}) over {proofs} proofs",
+                        );
+                        num_proofs -= 1;
+                        continue;
+                    }
+                    ProvingError::NotAwaitingProof => {
+                        info!(
+                            "Skipped awaiting proof for {num_blocks} blocks ({starting_block}..{last_block})",
+                        );
+                        num_proofs -= 1;
                         continue;
                     }
                 }
@@ -309,57 +323,59 @@ pub async fn prove(mut args: ProveArgs) -> anyhow::Result<()> {
         }
     }
 
-    // gather sorted proofs into vec
-    let proofs = result_pq
-        .into_sorted_vec()
-        .into_iter()
-        .rev()
-        .map(|r| r.result.expect("Failed to get result"))
-        .collect::<Vec<_>>();
-
-    // stitch contiguous proofs together
-    if proofs.len() > 1 {
-        info!("Composing {} proofs together.", proofs.len());
-        // construct a proving instruction with no blocks to derive
-        let mut base_args = args;
-        {
-            // set last block as starting point
-            base_args.kona.agreed_l2_output_root = base_args.kona.claimed_l2_output_root;
-            let l2_provider = l2_provider.as_ref().unwrap();
-            base_args.kona.agreed_l2_head_hash = await_tel!(
-                context,
-                tracer,
-                "l2_provider get_block_by_number claimed_l2_block_number",
-                retry_res_ctx_timeout!(l2_provider
-                    .get_block_by_number(BlockNumberOrTag::Number(
-                        base_args.kona.claimed_l2_block_number,
-                    ))
-                    .await
-                    .context("l2_provider get_block_by_number claimed_l2_block_number")?
-                    .ok_or_else(|| anyhow!("Claimed L2 block not found")))
-            )
-            .header
-            .hash;
-        }
-        // construct a list of boot info to backward stitch
-        let stitched_boot_info = proofs
-            .iter()
-            .map(StitchedBootInfo::from)
+    if !args.proving.skip_stitching() {
+        // gather sorted proofs into vec
+        let proofs = result_pq
+            .into_sorted_vec()
+            .into_iter()
+            .rev()
+            .map(|r| r.result.expect("Failed to get result"))
             .collect::<Vec<_>>();
 
-        crate::tasks::compute_fpvm_proof(
-            base_args,
-            rollup_config.clone(),
-            disk_kv_store.clone(),
-            precondition_hash,
-            precondition_validation_data_hash,
-            stitched_boot_info,
-            proofs,
-            true,
-            task_channel.0.clone(),
-        )
-        .await
-        .context("Failed to compute FPVM proof.")?;
+        // stitch contiguous proofs together
+        if proofs.len() > 1 {
+            info!("Composing {} proofs together.", proofs.len());
+            // construct a proving instruction with no blocks to derive
+            let mut base_args = args;
+            {
+                // set last block as starting point
+                base_args.kona.agreed_l2_output_root = base_args.kona.claimed_l2_output_root;
+                let l2_provider = l2_provider.as_ref().unwrap();
+                base_args.kona.agreed_l2_head_hash = await_tel!(
+                    context,
+                    tracer,
+                    "l2_provider get_block_by_number claimed_l2_block_number",
+                    retry_res_ctx_timeout!(l2_provider
+                        .get_block_by_number(BlockNumberOrTag::Number(
+                            base_args.kona.claimed_l2_block_number,
+                        ))
+                        .await
+                        .context("l2_provider get_block_by_number claimed_l2_block_number")?
+                        .ok_or_else(|| anyhow!("Claimed L2 block not found")))
+                )
+                .header
+                .hash;
+            }
+            // construct a list of boot info to backward stitch
+            let stitched_boot_info = proofs
+                .iter()
+                .map(StitchedBootInfo::from)
+                .collect::<Vec<_>>();
+
+            crate::tasks::compute_fpvm_proof(
+                base_args,
+                rollup_config.clone(),
+                disk_kv_store.clone(),
+                precondition_hash,
+                precondition_validation_data_hash,
+                stitched_boot_info,
+                proofs,
+                true,
+                task_channel.0.clone(),
+            )
+            .await
+            .context("Failed to compute FPVM proof.")?;
+        }
     }
 
     info!("Exiting prover program.");

--- a/crates/sync/src/provider/beacon.rs
+++ b/crates/sync/src/provider/beacon.rs
@@ -46,6 +46,7 @@ impl BlobProvider {
             tracer,
             "BlobProvider::client_get (genesis)",
             retry_res_timeout!(
+                10,
                 Self::client_get::<Value>(&client, &cl_node_endpoint, "eth/v1/beacon/genesis")
                     .with_context(context.clone())
                     .await
@@ -61,6 +62,7 @@ impl BlobProvider {
             tracer,
             "BlobProvider::client_get (spec)",
             retry_res_timeout!(
+                10,
                 Self::client_get::<Value>(&client, &cl_node_endpoint, "eth/v1/config/spec")
                     .with_context(context.clone())
                     .await
@@ -119,6 +121,7 @@ impl BlobProvider {
             tracer,
             "BlobProvider::get",
             retry_res_timeout!(
+                10,
                 self.get::<BeaconBlobBundle>(&format!("eth/v1/beacon/blob_sidecars/{slot}"))
                     .with_context(context.clone())
                     .await

--- a/crates/sync/src/retry.rs
+++ b/crates/sync/src/retry.rs
@@ -88,7 +88,7 @@ macro_rules! retry_res_ctx {
 #[macro_export]
 macro_rules! retry_timeout {
     ($e:expr) => {
-        $crate::retry_timeout!(2, 250, 1000, $e)
+        $crate::retry_timeout!(5, 250, 1000, $e)
     };
     ($t:expr, $e:expr) => {
         $crate::retry_timeout!($t, 250, 1000, $e)
@@ -108,7 +108,7 @@ macro_rules! retry_timeout {
 #[macro_export]
 macro_rules! retry_res_timeout {
     ($e:expr) => {
-        $crate::retry_res_timeout!(2, 250, 1000, $e)
+        $crate::retry_res_timeout!(5, 250, 1000, $e)
     };
     ($t:expr, $e:expr) => {
         $crate::retry_res_timeout!($t, 250, 1000, $e)
@@ -134,7 +134,7 @@ macro_rules! retry_res_timeout {
 #[macro_export]
 macro_rules! retry_res_ctx_timeout {
     ($e:expr) => {
-        $crate::retry_res_ctx_timeout!(2, 250, 1000, $e)
+        $crate::retry_res_ctx_timeout!(5, 250, 1000, $e)
     };
     ($t:expr, $e:expr) => {
         $crate::retry_res_ctx_timeout!($t, 250, 1000, $e)

--- a/crates/validator/src/args.rs
+++ b/crates/validator/src/args.rs
@@ -28,7 +28,10 @@ pub struct ValidateArgs {
     /// Path to the prover binary to use for proving
     #[clap(long, env)]
     pub kailua_cli: Option<PathBuf>,
-    /// Fast-forward block height
+    /// Block height to start fast-forwarding finality
+    #[clap(long, env, required = false, default_value_t = 0)]
+    pub fast_forward_start: u64,
+    /// Block height to end fast-forwarding finality
     #[clap(long, env, required = false, default_value_t = 0)]
     pub fast_forward_target: u64,
     /// How many proofs to compute simultaneously

--- a/crates/validator/src/proposals.rs
+++ b/crates/validator/src/proposals.rs
@@ -233,8 +233,10 @@ pub async fn handle_proposals(
                 error!("Canonical status of proposal {proposal_index} unknown");
                 continue;
             };
-            // utilize validity proofs for proposals of height below the ff target
-            if proposal.output_block_number <= args.fast_forward_target {
+            // utilize validity proofs for proposals of height within the ff range
+            if (args.fast_forward_start..=args.fast_forward_target)
+                .contains(&proposal.output_block_number)
+            {
                 // prove the validity of this proposal if it is canon
                 if is_proposal_canonical {
                     // Prove full validity

--- a/crates/validator/src/tasks.rs
+++ b/crates/validator/src/tasks.rs
@@ -106,6 +106,12 @@ pub async fn handle_proving_tasks(
             }
         };
 
+        // we do not get a stitched proof w/o all proofs
+        if !insufficient_l1_data && prove_args.proving.skip_stitching() {
+            info!("Skipping proving task.");
+            continue;
+        }
+
         // wait for io then read computed proof from disk
         sleep(Duration::from_secs(1)).await;
         match read_bincoded_file(&proof_file_name).await {

--- a/crates/validator/src/tasks.rs
+++ b/crates/validator/src/tasks.rs
@@ -56,6 +56,7 @@ pub async fn handle_proving_tasks(
             warn!("handle_proving_tasks terminated");
             break Ok(());
         };
+        info!("Handling proof request for local index {proposal_index}.");
 
         let insufficient_l1_data = if let Some(kailua_cli) = &kailua_cli {
             info!("Invoking prover binary.");
@@ -125,6 +126,7 @@ pub async fn handle_proving_tasks(
                     warn!("Cannot prove local index {proposal_index} due to insufficient l1 head.");
                 } else {
                     // retry proving task
+                    info!("Resubmitting proving task for local index {proposal_index}.");
                     task_channel
                         .0
                         .send(Task {

--- a/crates/validator/src/validate.rs
+++ b/crates/validator/src/validate.rs
@@ -32,11 +32,11 @@ pub async fn validate(
 
     // Sanitize proving arguments
     if args.proving.skip_await_proof {
-        warn!("Validator cannot accept skip-await-proof flag.");
+        warn!("Validator ignores the skip-await-proof flag.");
         args.proving.skip_await_proof = false;
     }
     if args.proving.skip_derivation_proof {
-        warn!("Validator cannot accept skip-derivation-proof flag.");
+        warn!("Validator ignores the skip-derivation-proof flag.");
         args.proving.skip_derivation_proof = false;
     }
 

--- a/justfile
+++ b/justfile
@@ -232,4 +232,4 @@ cleanup:
     rm ./*.fake
 
 grep-proving-log log:
-    grep -v -e block_builder -e batch_validator -e attributes_queue -e client_derivation_driver -e single_hint_handler -e kailua_common -e complete, -e client_blob_oracle -e agent -e channel_assembler -e kailua_sync {{log}}
+    grep -v -e kona_protocol -e R0VM -e block_builder -e batch_validator -e attributes_queue -e client_derivation_driver -e single_hint_handler -e kailua_common -e complete, -e client_blob_oracle -e agent -e channel_assembler -e kailua_sync {{log}}

--- a/justfile
+++ b/justfile
@@ -230,3 +230,6 @@ test-offline target="release" verbosity="": (prove-offline "16491249" "0x33a3e57
 cleanup:
     echo "Cleanup: Removing any .fake receipt files in directory."
     rm ./*.fake
+
+grep-proving-log log:
+    grep -v -e block_builder -e batch_validator -e attributes_queue -e client_derivation_driver -e single_hint_handler -e kailua_common -e complete, -e client_blob_oracle -e agent -e channel_assembler -e kailua_sync {{log}}


### PR DESCRIPTION
* Introduces a `bonsai` CLI command to manually retrieve proofs on Bonsai by their session ID. 
* Added retry logic to proving on Bonsai and Boundless to avoid inadvertent workload splitting.
* Added a `fast-forward-start` parameter that allows the validator to validity prove a proposal without its lineage.
* Support `skip-derivation-proof` and `skip-await-proof` in demo proving.
* Support concurrent Boundless provers.
* Support proving only every Nth request in demo proving.
* Support Boundless bidding start delays.
* Support configurable Boundless order staking per megacycle.
* Support caching Binary/Input uploads in Boundless.
* Support assuming cycle counts instead of preflights in Boundless.
* Support `skip-await-proof` in local prover.
* Support `skip-await-proof` when proving internally without a `kailua-cli` argument.
* Human readable upload sizes.
* Increase beacon chain timeouts to 10s.