### PR TITLE
chore: Fix Typos

### DIFF
--- a/crates/kona/src/kona.rs
+++ b/crates/kona/src/kona.rs
@@ -224,7 +224,7 @@ impl<T: CommsClient + Sync + Send> ChainProvider for OracleL1ChainProvider<T> {
         let transactions = trie_walker
             .into_iter()
             .map(|(_, rlp)| {
-                // note: not short-handed for error type coersion w/ `?`.
+                // note: not short-handed for error type coercion w/ `?`.
                 let rlp = TxEnvelope::decode_2718(&mut rlp.as_ref())?;
                 Ok(rlp)
             })

--- a/crates/prover/src/tasks.rs
+++ b/crates/prover/src/tasks.rs
@@ -619,7 +619,7 @@ pub async fn compute_cached_proof(
             .await
             .map_err(|e| ProvingError::OtherError(anyhow!(e)))?
             {
-                // If we have used debug_executionWitness sucessfully then don't use Kona's
+                // If we have used debug_executionWitness successfully then don't use Kona's
                 // debug_executePayload logic as it doesn't have caching
                 args.kona.enable_experimental_witness_endpoint = false;
             }


### PR DESCRIPTION
## Description

Corrected misspellings:

- `coersion` → `coercion`
- `sucessfully` → `successfully`