### PR TITLE
feat: Implement dynamic pricing using Boundless SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2664,9 +2664,8 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f56a871828b537886d3425879a6f6d5f83033a55a2f75cbd7c7c3298efd13eb"
+version = "1.4.0-rc.0"
+source = "git+https://github.com/boundless-xyz/boundless.git?branch=release-1.4#c5e6aa7d159d79cc056927d6a80a8ee69449c35a"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2694,8 +2693,6 @@ dependencies = [
  "moka",
  "rand 0.9.2",
  "reqwest 0.13.2",
- "reqwest-middleware",
- "reqwest-retry",
  "risc0-aggregation",
  "risc0-binfmt",
  "risc0-ethereum-contracts",
@@ -2711,6 +2708,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-tungstenite 0.24.0",
+ "tokio-util",
  "toml 0.8.23",
  "tower 0.5.2",
  "tracing",
@@ -9906,41 +9904,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest-middleware"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199dda04a536b532d0cc04d7979e39b1c763ea749bf91507017069c00b96056f"
-dependencies = [
- "anyhow",
- "async-trait",
- "http 1.2.0",
- "reqwest 0.13.2",
- "thiserror 2.0.18",
- "tower-service",
-]
-
-[[package]]
-name = "reqwest-retry"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2412db2af7d2268e7a5406be0431f37d9eb67ff390f35b395716f5f06c2eaa"
-dependencies = [
- "anyhow",
- "async-trait",
- "futures",
- "getrandom 0.2.15",
- "http 1.2.0",
- "hyper 1.8.1",
- "reqwest 0.13.2",
- "reqwest-middleware",
- "retry-policies",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "wasmtimer",
-]
-
-[[package]]
 name = "reth-chainspec"
 version = "1.9.1"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.1#3afe69a5738459a7cb5f46c598c7f541a1510f32"
@@ -10160,15 +10123,6 @@ dependencies = [
  "nybbles 0.4.3",
  "reth-primitives-traits",
  "revm-database 9.0.6",
-]
-
-[[package]]
-name = "retry-policies"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
-dependencies = [
- "rand 0.9.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2664,8 +2664,9 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "1.4.0-rc.0"
-source = "git+https://github.com/boundless-xyz/boundless.git?branch=release-1.4#c5e6aa7d159d79cc056927d6a80a8ee69449c35a"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd9d445a56000478af5419c59f1f64299e48f0d010340e9dd737f0971f617857"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,8 +143,7 @@ risc0-ethereum-contracts = "3.0.1"
 risc0-zkvm = { version = "3.0.5", features = ["heap-embedded-alloc", "unstable"] }
 
 # Boundless
-# TODO: Switch to crates.io release once boundless-market 1.4.0 is published (expected imminently).
-boundless-market = { git = "https://github.com/boundless-xyz/boundless.git", branch = "release-1.4", features = ["gcs", "s3"] }
+boundless-market = { version = "1.4", features = ["gcs", "s3"] }
 
 # STEEL
 risc0-steel = { git = "https://github.com/boundless-xyz/steel.git", tag = "v2.4.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,8 @@ risc0-ethereum-contracts = "3.0.1"
 risc0-zkvm = { version = "3.0.5", features = ["heap-embedded-alloc", "unstable"] }
 
 # Boundless
-boundless-market = { version = "1.3.3", features = ["gcs", "s3"] }
+# TODO: Switch to crates.io release once boundless-market 1.4.0 is published (expected imminently).
+boundless-market = { git = "https://github.com/boundless-xyz/boundless.git", branch = "release-1.4", features = ["gcs", "s3"] }
 
 # STEEL
 risc0-steel = { git = "https://github.com/boundless-xyz/steel.git", tag = "v2.4.2" }

--- a/book/src/validator.md
+++ b/book/src/validator.md
@@ -167,7 +167,7 @@ Extra parameters and environment variables can be specified to determine exactly
 generation takes place.
 Running using only the parameters above will generate proofs using the local RISC Zero prover available to the validator.
 Alternatively, proof generation can be delegated to an external service such as [Bonsai](https://risczero.com/bonsai),
-or to the decentralized [Boundless proving network](https://docs.beboundless.xyz/).
+or to the decentralized [Boundless proving network](https://docs.boundless.network/).
 
 ```admonish note
 All data required to generate the proof can be publicly derived from the public chain data available for your rollup,
@@ -184,17 +184,22 @@ Running `kailua-cli validate` with these two environment variables should now de
 ```
 
 ### Boundless
-When delegating generation of Kailua Fault proofs to the decentralized [Boundless proving network](https://docs.beboundless.xyz/),
+When delegating generation of Kailua Fault proofs to the decentralized [Boundless proving network](https://docs.boundless.network/),
 for every fault proof, a proof request is submitted to the network, where it goes through the standard
-[proof life-cycle](https://docs.beboundless.xyz/provers/proof-lifecycle) on boundless, before being published by
+[proof life-cycle](https://docs.boundless.network/developers/proof-lifecycle) on Boundless, before being published by
 your validator to settle a dispute.
 
-This functionality requires some additional parameters when starting the validator.
-These parameters can be passed in as CLI arguments or set as environment variables
+Pricing, timing, and collateral for proof requests are handled automatically by the
+[Boundless SDK](https://docs.boundless.network/developers/tutorials/request). The SDK determines
+appropriate prices from market data and gas costs, sets cycle-aware timeouts, and uses chain-specific
+collateral defaults. See the [auction parameter guide](https://docs.boundless.network/developers/tutorials/auction)
+for details on how the reverse Dutch auction works.
 
-#### Proof Requests
-The following first set of parameters determine where/how requests are made:
-* `boundless-rpc-url`: The rpc endpoint of the L1 chain where the Boundless network is deployed.
+This functionality requires some additional parameters when starting the validator.
+These parameters can be passed in as CLI arguments or set as environment variables.
+
+#### Connection
+* `boundless-rpc-url`: The RPC endpoint of the L1 chain where the Boundless network is deployed.
 * `boundless-wallet-key`: The wallet private key to use to send proof request transactions.
 * `boundless-order-stream-url`: (Optional) The URL to use for off-chain order submission.
 * `boundless-chain-id`: EIP-155 chain ID of the network hosting Boundless.
@@ -202,38 +207,53 @@ The following first set of parameters determine where/how requests are made:
 * `boundless-set-verifier-address`: The address of the RISC Zero verifier supporting aggregated proofs for order validation.
 * `boundless-market-address`: The address of the Boundless market contract.
 * `boundless-collateral-token-address`: Address of the stake collateral ERC-20 contract.
-* `boundless-lookback`: (Defaults to `true`) Whether to inspect for duplicates before making a new proof request.
-* `boundless-assume-cycle-count`: Whether to skip preflighting execution and assume the given cycle count.
+
+#### Execution Estimation
+* `boundless-look-back`: (Defaults to `true`) Whether to inspect for duplicates before making a new proof request.
+* `boundless-assume-cycle-count`: Skip preflighting execution and assume the given cycle count.
 * `boundless-assume-cycles-per-gas`: Skip preflighting and assume a fixed cycle count per gas.
 * `boundless-assume-cycles-per-byte`: Skip preflighting and assume a fixed cycle count per input byte.
 * `boundless-assume-cycles-per-snark`: Skip preflighting and assume a fixed cycle count per recursive snark.
-* `boundless-expired-price-inc-perc`: Percentage to increase the price of a proving order by after it expires (Default 10).
-* `boundless-expired-time-inc-perc`: Percentage to increase the time allowed for a proving order by after it expires (Default 4).
-* `boundless-cycle-min-wei`: (Defaults to `200000000`) Starting price (wei) per cycle of proving.
-* `boundless-cycle-max-wei`: (Defaults to `600000000`) Maximum price (wei) per cycle of proving.
-* `boundless-mega-cycle-min`: Minimum megacycles per proving order (Default 250).
-* `boundless-mega-cycle-collateral`: Collateral (ZKC) per megacycle of the proving order (Default `2500000000000000`).
-* `boundless-order-min-collateral`: Minimum collateral (ZKC) per proving order (Default `5000000000000000000`).
-* `boundless-order-bid-delay-factor`: Multiplier for delay before order price starts ramping up (Default 0.5).
-* `boundless-order-min-bid-delay`: Minimum number of seconds to set as bid delay time (Default 120).
-* `boundless-order-ramp-up-factor`: (Defaults to `1.0`) Multiplier for order price to ramp up to maximum.
-* `boundless-order-min-ramp-up`: Minimum number of seconds to set as ramp up time (Default 600).
-* `boundless-order-lock-timeout-factor`: (Defaults to `3`) Multiplier for order fulfillment timeout after locking.
-* `boundless-order-min-lock-timeout`: Minimum number of seconds to set as lock timeout time (Default 1200).
-* `boundless-order-expiry-factor`: (Defaults to `1.0`) Multiplier for order expiry timeout after creation.
-* `boundless-order-min-expiry`: Minimum number of seconds to set as expiry time (Default 900).
-* `boundless-order-check-interval`: (Defaults to `12`) Time in seconds between attempts to check order status.
-* `boundless-enable-upload-caching`: Whether to enable image/input upload caching.
+
+#### Pricing
+By default, the Boundless SDK sets pricing automatically based on market conditions and gas costs.
+The following optional parameters allow you to override the SDK defaults:
+* `boundless-min-price-per-cycle`: Minimum price per cycle, e.g. `"0.00001 USD"` or `"0.0000001 ETH"`. Requires a unit. If unset, the SDK uses market pricing from the price provider.
+* `boundless-max-price-per-cycle`: Maximum price per cycle, same format. If unset, the SDK uses a market-calibrated default plus a gas cost buffer.
+* `boundless-max-price-cap`: Hard cap on total order price (e.g. `"0.5 ETH"`, `"100 USD"`). Safety mechanism to prevent excessive spending.
+
+#### Retry Escalation
+When a proof request expires without being fulfilled, it is automatically resubmitted with increased pricing and timeouts:
+* `boundless-expired-price-inc-perc`: Percentage to increase the price by per retry attempt (Default 10).
+* `boundless-expired-time-inc-perc`: Percentage to increase timeouts by per retry attempt (Default 4).
+
+#### Order Submission
 * `boundless-order-submission-cooldown`: Time in seconds between attempts to submit new orders (Default 12).
+* `boundless-order-check-interval`: (Defaults to `12`) Time in seconds between attempts to check order status.
+* `boundless-enable-upload-caching`: Whether to enable image/input upload caching (Default `true`).
+
+#### Funding
 * `boundless-order-funding-mode`: Funding mode for order submission. One of `never`, `always`, `available-balance`, or `below-threshold` (Default `never`).
 * `boundless-order-funding-threshold`: Threshold (wei) for `below-threshold` funding mode.
 
-```admonish note
-Order timeouts are set by default to the number of megacycles in a proof request.
-The multipliers allow you to scale these timeouts according to your expected proving speeds.
-The default scale values give a 1 MHz prover 3x the amount of time it needs to fulfill a request once it's locked, and 
-10x its expected proving time as overall timeout.
-```
+#### Legacy Pricing
+For backward compatibility, static wei-based pricing can be enabled with `--boundless-legacy-pricing`.
+When this flag is set, the SDK's dynamic pricing is bypassed and the following parameters are used instead.
+These flags are hidden from `--help` and require `--boundless-legacy-pricing` to be set.
+
+* `boundless-cycle-min-wei`: Starting price (wei) per cycle (Default `200000000`).
+* `boundless-cycle-max-wei`: Maximum price (wei) per cycle (Default `600000000`).
+* `boundless-mega-cycle-min`: Minimum megacycles per proving order (Default 250).
+* `boundless-mega-cycle-collateral`: Collateral (ZKC) per megacycle (Default `2500000000000000`).
+* `boundless-order-min-collateral`: Minimum collateral (ZKC) per order (Default `5000000000000000000`).
+* `boundless-order-bid-delay-factor`: Multiplier for delay before price ramp-up starts (Default 0.5).
+* `boundless-order-min-bid-delay`: Minimum bid delay in seconds (Default 120).
+* `boundless-order-ramp-up-factor`: Multiplier for price ramp-up duration (Default 1.0).
+* `boundless-order-min-ramp-up`: Minimum ramp-up time in seconds (Default 600).
+* `boundless-order-lock-timeout-factor`: Multiplier for lock timeout (Default 3.0).
+* `boundless-order-min-lock-timeout`: Minimum lock timeout in seconds (Default 1200).
+* `boundless-order-expiry-factor`: Multiplier for order expiry (Default 1.0).
+* `boundless-order-min-expiry`: Minimum expiry time in seconds (Default 900).
 
 #### Storage Uploader
 The below second set of parameters determine where the proven executable and its input are stored:
@@ -254,7 +274,7 @@ The below second set of parameters determine where the proven executable and its
 * `r2-domain`: Custom domain for file retrieval. Currently used to upload with a custom prefix and replace the download URL with this domain.
 
 ```admonish success
-Running `kailua-cli validate` with the above extra arguments should now delegate all validator proving to the [Boundless proving network](https://docs.beboundless.xyz/)!
+Running `kailua-cli validate` with the above extra arguments should now delegate all validator proving to the [Boundless proving network](https://docs.boundless.network/)!
 ```
 
 

--- a/crates/prover/src/risczero/boundless.rs
+++ b/crates/prover/src/risczero/boundless.rs
@@ -34,6 +34,7 @@ use boundless_market::contracts::boundless_market::MarketError;
 use boundless_market::contracts::{
     Predicate, RequestError, RequestId, RequestStatus, Requirements,
 };
+use boundless_market::price_oracle::{Amount, Asset};
 use boundless_market::request_builder::{OfferParams, RequirementParams};
 use boundless_market::storage::{StorageUploaderConfig, StorageUploaderType};
 use boundless_market::{Deployment, GuestEnv, ProofRequest, StandardUploader};
@@ -128,7 +129,6 @@ pub struct MarketProviderConfig {
     /// Whether to look back at prior proof requests
     #[clap(long, env, required = false, default_value_t = true)]
     pub boundless_look_back: bool,
-
     /// Whether to skip preflighting execution and assume a fixed cycle count.
     #[clap(long, env, required = false)]
     pub boundless_assume_cycle_count: Option<u64>,
@@ -142,6 +142,28 @@ pub struct MarketProviderConfig {
     #[clap(long, env, required = false)]
     pub boundless_assume_cycles_per_snark: Option<u64>,
 
+    /// Minimum price per cycle (e.g., "0.00001 USD", "0.0000001 ETH").
+    /// If unset, the SDK uses market pricing from the price provider.
+    #[clap(
+        long,
+        env,
+        required = false,
+        conflicts_with = "boundless_legacy_pricing"
+    )]
+    pub boundless_min_price_per_cycle: Option<String>,
+    /// Maximum price per cycle (e.g., "0.00001 USD", "0.0000001 ETH").
+    /// If unset, the SDK default (~100 Kwei/cycle, 99th percentile) is used.
+    #[clap(
+        long,
+        env,
+        required = false,
+        conflicts_with = "boundless_legacy_pricing"
+    )]
+    pub boundless_max_price_per_cycle: Option<String>,
+    /// Hard cap on total order price (e.g., "0.5 ETH", "100 USD"). Safety mechanism.
+    #[clap(long, env, required = false)]
+    pub boundless_max_price_cap: Option<String>,
+
     /// How much % to increase the price of the proving order by after it expires.
     #[clap(long, env, required = false, default_value_t = 10)]
     pub boundless_expired_price_inc_perc: u64,
@@ -149,45 +171,9 @@ pub struct MarketProviderConfig {
     #[clap(long, env, required = false, default_value_t = 4)]
     pub boundless_expired_time_inc_perc: u64,
 
-    /// Starting price (wei) per cycle of the proving order
-    #[clap(long, env, required = false, default_value = "200000000")]
-    pub boundless_cycle_min_wei: U256,
-    /// Maximum price (wei) per cycle of the proving order
-    #[clap(long, env, required = false, default_value = "600000000")]
-    pub boundless_cycle_max_wei: U256,
-    /// Minimum megacycles per proving order
-    #[clap(long, env, required = false, default_value_t = 250)]
-    pub boundless_mega_cycle_min: u64,
-    /// Collateral (ZKC) per megacycle of the proving order
-    #[clap(long, env, required = false, default_value = "2500000000000000")]
-    pub boundless_mega_cycle_collateral: U256,
-    /// Minimum collateral (ZKC) per proving order
-    #[clap(long, env, required = false, default_value = "5000000000000000000")]
-    pub boundless_order_min_collateral: U256,
-    /// Multiplier for delay before order price starts ramping up.
-    #[clap(long, env, required = false, default_value_t = 0.5)]
-    pub boundless_order_bid_delay_factor: f64,
-    /// Minimum number of seconds to set as bid delay time
-    #[clap(long, env, required = false, default_value_t = 120)]
-    pub boundless_order_min_bid_delay: u64,
-    /// Multiplier for order price to ramp up from min to max.
-    #[clap(long, env, required = false, default_value_t = 1.0)]
-    pub boundless_order_ramp_up_factor: f64,
-    /// Minimum number of seconds to set as ramp up time
-    #[clap(long, env, required = false, default_value_t = 600)]
-    pub boundless_order_min_ramp_up: u32,
-    /// Multiplier for order fulfillment timeout (seconds/segment) after locking
-    #[clap(long, env, required = false, default_value_t = 3.0)]
-    pub boundless_order_lock_timeout_factor: f64,
-    /// Minimum number of seconds to set as lock timeout time
-    #[clap(long, env, required = false, default_value_t = 1200)]
-    pub boundless_order_min_lock_timeout: u32,
-    /// Multiplier for order expiry timeout (seconds/segment) after lock timeout
-    #[clap(long, env, required = false, default_value_t = 1.0)]
-    pub boundless_order_expiry_factor: f64,
-    /// Minimum number of seconds to set as expiry time
-    #[clap(long, env, required = false, default_value_t = 900)]
-    pub boundless_order_min_expiry: u32,
+    /// Time in seconds between attempts to submit new orders
+    #[clap(long, env, required = false, default_value_t = 12)]
+    pub boundless_order_submission_cooldown: u64,
     /// Time in seconds between attempts to check order status
     #[clap(long, env, required = false, default_value_t = 12)]
     pub boundless_order_check_interval: u64,
@@ -195,20 +181,150 @@ pub struct MarketProviderConfig {
     #[clap(long, env, required = false, default_value_t = true)]
     pub boundless_enable_upload_caching: bool,
 
-    /// Time in seconds between attempts to submit new orders
-    #[clap(long, env, required = false, default_value_t = 12)]
-    pub boundless_order_submission_cooldown: u64,
-
     /// Funding mode for order submission.
     /// Options: "never", "always", "available-balance", "below-threshold".
     /// When "below-threshold", also set --boundless-order-funding-threshold.
     #[clap(long, env, required = false, default_value = "never")]
     pub boundless_order_funding_mode: String,
-
     /// Threshold (wei) for below-threshold funding mode.
     /// Only used when --boundless-order-funding-mode is "below-threshold".
     #[clap(long, env, required = false)]
     pub boundless_order_funding_threshold: Option<U256>,
+
+    /// Use legacy static wei-based pricing instead of dynamic SDK pricing.
+    /// When enabled, the flags below are used instead of the SDK's OfferLayer.
+    #[clap(long, env, required = false, default_value_t = false)]
+    pub boundless_legacy_pricing: bool,
+    /// Starting price (wei) per cycle.
+    #[clap(
+        long,
+        env,
+        required = false,
+        default_value = "200000000",
+        hide = true,
+        requires = "boundless_legacy_pricing"
+    )]
+    pub boundless_cycle_min_wei: U256,
+    /// Maximum price (wei) per cycle.
+    #[clap(
+        long,
+        env,
+        required = false,
+        default_value = "600000000",
+        hide = true,
+        requires = "boundless_legacy_pricing"
+    )]
+    pub boundless_cycle_max_wei: U256,
+    /// Minimum megacycles per proving order.
+    #[clap(
+        long,
+        env,
+        required = false,
+        default_value_t = 250,
+        hide = true,
+        requires = "boundless_legacy_pricing"
+    )]
+    pub boundless_mega_cycle_min: u64,
+    /// Collateral (ZKC) per megacycle.
+    #[clap(
+        long,
+        env,
+        required = false,
+        default_value = "2500000000000000",
+        hide = true,
+        requires = "boundless_legacy_pricing"
+    )]
+    pub boundless_mega_cycle_collateral: U256,
+    /// Minimum collateral (ZKC) per order.
+    #[clap(
+        long,
+        env,
+        required = false,
+        default_value = "5000000000000000000",
+        hide = true,
+        requires = "boundless_legacy_pricing"
+    )]
+    pub boundless_order_min_collateral: U256,
+    /// Multiplier for delay before order price starts ramping up.
+    #[clap(
+        long,
+        env,
+        required = false,
+        default_value_t = 0.5,
+        hide = true,
+        requires = "boundless_legacy_pricing"
+    )]
+    pub boundless_order_bid_delay_factor: f64,
+    /// Minimum number of seconds to set as bid delay time.
+    #[clap(
+        long,
+        env,
+        required = false,
+        default_value_t = 120,
+        hide = true,
+        requires = "boundless_legacy_pricing"
+    )]
+    pub boundless_order_min_bid_delay: u64,
+    /// Multiplier for order price to ramp up from min to max.
+    #[clap(
+        long,
+        env,
+        required = false,
+        default_value_t = 1.0,
+        hide = true,
+        requires = "boundless_legacy_pricing"
+    )]
+    pub boundless_order_ramp_up_factor: f64,
+    /// Minimum number of seconds to set as ramp up time.
+    #[clap(
+        long,
+        env,
+        required = false,
+        default_value_t = 600,
+        hide = true,
+        requires = "boundless_legacy_pricing"
+    )]
+    pub boundless_order_min_ramp_up: u32,
+    /// Multiplier for order fulfillment timeout (seconds/segment) after locking.
+    #[clap(
+        long,
+        env,
+        required = false,
+        default_value_t = 3.0,
+        hide = true,
+        requires = "boundless_legacy_pricing"
+    )]
+    pub boundless_order_lock_timeout_factor: f64,
+    /// Minimum number of seconds to set as lock timeout time.
+    #[clap(
+        long,
+        env,
+        required = false,
+        default_value_t = 1200,
+        hide = true,
+        requires = "boundless_legacy_pricing"
+    )]
+    pub boundless_order_min_lock_timeout: u32,
+    /// Multiplier for order expiry timeout (seconds/segment) after lock timeout.
+    #[clap(
+        long,
+        env,
+        required = false,
+        default_value_t = 1.0,
+        hide = true,
+        requires = "boundless_legacy_pricing"
+    )]
+    pub boundless_order_expiry_factor: f64,
+    /// Minimum number of seconds to set as expiry time.
+    #[clap(
+        long,
+        env,
+        required = false,
+        default_value_t = 900,
+        hide = true,
+        requires = "boundless_legacy_pricing"
+    )]
+    pub boundless_order_min_expiry: u32,
 }
 
 impl MarketProviderConfig {
@@ -286,34 +402,54 @@ impl MarketProviderConfig {
                 cycle_count.to_string(),
             ]);
         }
-        // Proving fee args
+        // Dynamic pricing args
+        if let Some(ref min_price) = self.boundless_min_price_per_cycle {
+            proving_args.extend(vec![
+                String::from("--boundless-min-price-per-cycle"),
+                min_price.clone(),
+            ]);
+        }
+        if let Some(ref max_price) = self.boundless_max_price_per_cycle {
+            proving_args.extend(vec![
+                String::from("--boundless-max-price-per-cycle"),
+                max_price.clone(),
+            ]);
+        }
+        if let Some(ref cap) = self.boundless_max_price_cap {
+            proving_args.extend(vec![String::from("--boundless-max-price-cap"), cap.clone()]);
+        }
+        if self.boundless_legacy_pricing {
+            proving_args.extend(vec![
+                String::from("--boundless-legacy-pricing"),
+                String::from("--boundless-cycle-min-wei"),
+                self.boundless_cycle_min_wei.to_string(),
+                String::from("--boundless-cycle-max-wei"),
+                self.boundless_cycle_max_wei.to_string(),
+                String::from("--boundless-mega-cycle-min"),
+                self.boundless_mega_cycle_min.to_string(),
+                String::from("--boundless-mega-cycle-collateral"),
+                self.boundless_mega_cycle_collateral.to_string(),
+                String::from("--boundless-order-min-collateral"),
+                self.boundless_order_min_collateral.to_string(),
+                String::from("--boundless-order-bid-delay-factor"),
+                self.boundless_order_bid_delay_factor.to_string(),
+                String::from("--boundless-order-min-bid-delay"),
+                self.boundless_order_min_bid_delay.to_string(),
+                String::from("--boundless-order-ramp-up-factor"),
+                self.boundless_order_ramp_up_factor.to_string(),
+                String::from("--boundless-order-min-ramp-up"),
+                self.boundless_order_min_ramp_up.to_string(),
+                String::from("--boundless-order-lock-timeout-factor"),
+                self.boundless_order_lock_timeout_factor.to_string(),
+                String::from("--boundless-order-min-lock-timeout"),
+                self.boundless_order_min_lock_timeout.to_string(),
+                String::from("--boundless-order-expiry-factor"),
+                self.boundless_order_expiry_factor.to_string(),
+                String::from("--boundless-order-min-expiry"),
+                self.boundless_order_min_expiry.to_string(),
+            ]);
+        }
         proving_args.extend(vec![
-            String::from("--boundless-cycle-min-wei"),
-            self.boundless_cycle_min_wei.to_string(),
-            String::from("--boundless-cycle-max-wei"),
-            self.boundless_cycle_max_wei.to_string(),
-            String::from("--boundless-mega-cycle-min"),
-            self.boundless_mega_cycle_min.to_string(),
-            String::from("--boundless-mega-cycle-collateral"),
-            self.boundless_mega_cycle_collateral.to_string(),
-            String::from("--boundless-order-min-collateral"),
-            self.boundless_order_min_collateral.to_string(),
-            String::from("--boundless-order-bid-delay-factor"),
-            self.boundless_order_bid_delay_factor.to_string(),
-            String::from("--boundless-order-min-bid-delay"),
-            self.boundless_order_min_bid_delay.to_string(),
-            String::from("--boundless-order-ramp-up-factor"),
-            self.boundless_order_ramp_up_factor.to_string(),
-            String::from("--boundless-order-min-ramp-up"),
-            self.boundless_order_min_ramp_up.to_string(),
-            String::from("--boundless-order-lock-timeout-factor"),
-            self.boundless_order_lock_timeout_factor.to_string(),
-            String::from("--boundless-order-min-lock-timeout"),
-            self.boundless_order_min_lock_timeout.to_string(),
-            String::from("--boundless-order-expiry-factor"),
-            self.boundless_order_expiry_factor.to_string(),
-            String::from("--boundless-order-min-expiry"),
-            self.boundless_order_min_expiry.to_string(),
             String::from("--boundless-order-check-interval"),
             self.boundless_order_check_interval.to_string(),
             String::from("--boundless-enable-upload-caching"),
@@ -480,6 +616,30 @@ pub async fn run_boundless_client<A: NoUninit + Into<Digest>>(
             .with_deployment(market_deployment.clone())
             .with_uploader(Some(storage_provider.clone()))
             .with_funding_mode(market.funding_mode())
+            .config_offer_layer(|config| {
+                // Set per-cycle price overrides if provided; otherwise SDK uses market prices or built-in defaults.
+                if let Some(ref min_price) = market.boundless_min_price_per_cycle {
+                    if let Ok(amount) = Amount::parse(min_price, None) {
+                        config.min_price_per_cycle(amount);
+                    } else {
+                        tracing::warn!(
+                            "Failed to parse --boundless-min-price-per-cycle '{}', using SDK default",
+                            min_price
+                        );
+                    }
+                }
+                if let Some(ref max_price) = market.boundless_max_price_per_cycle {
+                    if let Ok(amount) = Amount::parse(max_price, None) {
+                        config.max_price_per_cycle(amount);
+                    } else {
+                        tracing::warn!(
+                            "Failed to parse --boundless-max-price-per-cycle '{}', using SDK default",
+                            max_price
+                        );
+                    }
+                }
+                config
+            })
             .build()
             .await
             .context("ClientBuilder::build()")
@@ -1096,52 +1256,8 @@ pub async fn request_proof<A: NoUninit + Into<Digest>>(
     // Build final request
     let boundless_wallet_address = boundless_client.signer.as_ref().unwrap().address();
 
-    let boundless_rpc_time = retry_res_timeout!(
-        15,
-        boundless_client
-            .provider()
-            .get_block_by_number(BlockNumberOrTag::Latest)
-            .await
-            .context("get_block_by_number latest")?
-            .ok_or_else(|| anyhow!("Failed to fetch latest block from Boundless RPC"))
-    )
-    .await
-    .header
-    .timestamp;
-
-    let priced_cycles =
-        U256::from((market.boundless_mega_cycle_min << 20).max(request_cycles.total_cycle_count));
-    let price_increase_numerator =
-        U256::from(100 + attempt * market.boundless_expired_price_inc_perc);
-    let min_price =
-        market.boundless_cycle_min_wei * priced_cycles * price_increase_numerator / U256::from(100);
-    let max_price =
-        market.boundless_cycle_max_wei * priced_cycles * price_increase_numerator / U256::from(100);
-
-    let time_increase_factor =
-        (attempt * market.boundless_expired_price_inc_perc) as f64 / 100.0 + 1.0;
-    let timed_mega_cycles = market
-        .boundless_mega_cycle_min
-        .max(request_cycles.total_cycle_count.div_ceil(1 << 20)) as f64
-        * time_increase_factor;
-    let bid_delay_time = market
-        .boundless_order_min_bid_delay
-        .max((market.boundless_order_bid_delay_factor * timed_mega_cycles) as u64);
-    let ramp_up_period = market
-        .boundless_order_min_ramp_up
-        .max((market.boundless_order_ramp_up_factor * timed_mega_cycles) as u32);
-    let lock_timeout = ramp_up_period
-        + market
-            .boundless_order_min_lock_timeout
-            .max((market.boundless_order_lock_timeout_factor * timed_mega_cycles) as u32);
-    let expiry = lock_timeout
-        + market
-            .boundless_order_min_expiry
-            .max((market.boundless_order_expiry_factor * timed_mega_cycles) as u32);
-    let lock_collateral = market
-        .boundless_order_min_collateral
-        .max(market.boundless_mega_cycle_collateral * U256::from(timed_mega_cycles));
-    let request = boundless_client
+    // Pre-set URLs, cycles, and request ID so the SDK skips upload, preflight, and nonce generation.
+    let request_params = boundless_client
         .new_request()
         .with_journal(journal)
         .with_cycles(request_cycles.total_cycle_count)
@@ -1156,37 +1272,129 @@ pub async fn request_proof<A: NoUninit + Into<Digest>>(
                 .context("Failed to convert Requirements")
                 .map_err(ProvingError::OtherError)?,
         )
-        .with_offer(
-            OfferParams::builder()
-                .min_price(min_price)
-                .max_price(max_price)
-                .bidding_start(boundless_rpc_time + bid_delay_time)
-                .lock_collateral(lock_collateral)
-                .ramp_up_period(ramp_up_period)
-                .lock_timeout(lock_timeout)
-                .timeout(expiry)
-                .build()
-                .context("OfferParamsBuilder::build()")
-                .map_err(ProvingError::OtherError)?,
-        )
         .with_request_id(RequestId::new(boundless_wallet_address, fresh_nonce));
 
-    // Send the request and wait for it to be completed.
-    let (request_id, expires_at) = if market.boundless_order_stream_url.is_some() {
-        info!("Submitting offchain request.");
+    let mut request = if market.boundless_legacy_pricing {
+        // Legacy path: manual pricing with static wei parameters
+        let boundless_rpc_time = retry_res_timeout!(
+            15,
+            boundless_client
+                .provider()
+                .get_block_by_number(BlockNumberOrTag::Latest)
+                .await
+                .context("get_block_by_number latest")?
+                .ok_or_else(|| anyhow!("Failed to fetch latest block from Boundless RPC"))
+        )
+        .await
+        .header
+        .timestamp;
+
+        let priced_cycles = U256::from(
+            (market.boundless_mega_cycle_min << 20).max(request_cycles.total_cycle_count),
+        );
+        let min_price = market.boundless_cycle_min_wei * priced_cycles;
+        let max_price = market.boundless_cycle_max_wei * priced_cycles;
+
+        let timed_mega_cycles = market
+            .boundless_mega_cycle_min
+            .max(request_cycles.total_cycle_count.div_ceil(1 << 20))
+            as f64;
+        let bid_delay_time = market
+            .boundless_order_min_bid_delay
+            .max((market.boundless_order_bid_delay_factor * timed_mega_cycles) as u64);
+        let ramp_up_period = market
+            .boundless_order_min_ramp_up
+            .max((market.boundless_order_ramp_up_factor * timed_mega_cycles) as u32);
+        let lock_timeout = ramp_up_period
+            + market
+                .boundless_order_min_lock_timeout
+                .max((market.boundless_order_lock_timeout_factor * timed_mega_cycles) as u32);
+        let expiry = lock_timeout
+            + market
+                .boundless_order_min_expiry
+                .max((market.boundless_order_expiry_factor * timed_mega_cycles) as u32);
+        let lock_collateral = market
+            .boundless_order_min_collateral
+            .max(market.boundless_mega_cycle_collateral * U256::from(timed_mega_cycles));
+
         boundless_client
-            .submit_offchain(request.clone())
+            .build_request(
+                request_params.with_offer(
+                    OfferParams::builder()
+                        .min_price(Amount::new(min_price, Asset::ETH))
+                        .max_price(Amount::new(max_price, Asset::ETH))
+                        .bidding_start(boundless_rpc_time + bid_delay_time)
+                        .lock_collateral(Amount::new(lock_collateral, Asset::ZKC))
+                        .ramp_up_period(ramp_up_period)
+                        .lock_timeout(lock_timeout)
+                        .timeout(expiry)
+                        .build()
+                        .context("OfferParamsBuilder::build()")
+                        .map_err(ProvingError::OtherError)?,
+                ),
+            )
             .await
-            .context("Client::submit_offchain()")
+            .context("Client::build_request (legacy)")
             .map_err(ProvingError::OtherError)?
     } else {
-        info!("Submitting onchain request.");
-        boundless_client
-            .submit_onchain(request.clone())
+        // Dynamic pricing: SDK computes pricing from market data, gas costs, and cycle count.
+        let request = boundless_client
+            .build_request(request_params)
             .await
-            .context("Client::submit_onchain()")
-            .map_err(ProvingError::OtherError)?
+            .context("Client::build_request")
+            .map_err(ProvingError::OtherError)?;
+
+        info!(
+            "SDK pricing: minPrice={}, maxPrice={}, rampUp={}s, lockTimeout={}s, timeout={}s, collateral={}",
+            request.offer.minPrice,
+            request.offer.maxPrice,
+            request.offer.rampUpPeriod,
+            request.offer.lockTimeout,
+            request.offer.timeout,
+            request.offer.lockCollateral,
+        );
+        request
     };
+
+    // Apply retry escalation on subsequent attempts
+    if attempt > 0 {
+        let price_scale = U256::from(100 + attempt * market.boundless_expired_price_inc_perc);
+        request.offer.minPrice = request.offer.minPrice * price_scale / U256::from(100);
+        request.offer.maxPrice = request.offer.maxPrice * price_scale / U256::from(100);
+
+        let time_scale = 1.0 + (attempt * market.boundless_expired_time_inc_perc) as f64 / 100.0;
+        request.offer.rampUpPeriod = (request.offer.rampUpPeriod as f64 * time_scale) as u32;
+        request.offer.lockTimeout = (request.offer.lockTimeout as f64 * time_scale) as u32;
+        request.offer.timeout = (request.offer.timeout as f64 * time_scale) as u32;
+
+        info!(
+            "Retry attempt {}: escalated minPrice={}, maxPrice={}, timeout={}s",
+            attempt, request.offer.minPrice, request.offer.maxPrice, request.offer.timeout,
+        );
+    }
+
+    // Apply max_price_cap safety (both paths)
+    if let Some(ref cap_str) = market.boundless_max_price_cap {
+        if let Ok(cap) = Amount::parse(cap_str, None) {
+            if request.offer.maxPrice > cap.value {
+                warn!(
+                    "maxPrice {} exceeds cap {}, capping",
+                    request.offer.maxPrice, cap_str
+                );
+                request.offer.maxPrice = cap.value;
+            }
+        } else {
+            warn!("Failed to parse --boundless-max-price-cap '{}'", cap_str);
+        }
+    }
+
+    // Submit the request (auto-selects offchain via order stream if available,
+    // otherwise falls back to onchain submission).
+    let (request_id, expires_at) = boundless_client
+        .submit_request(&request)
+        .await
+        .context("Client::submit_request")
+        .map_err(ProvingError::OtherError)?;
     info!(
         "Boundless request 0x{request_id:x} submitted. ({} sec cooldown).",
         market.boundless_order_submission_cooldown

--- a/crates/prover/src/risczero/boundless.rs
+++ b/crates/prover/src/risczero/boundless.rs
@@ -150,7 +150,7 @@ pub struct MarketProviderConfig {
         required = false,
         conflicts_with = "boundless_legacy_pricing"
     )]
-    pub boundless_min_price_per_cycle: Option<String>,
+    pub boundless_min_price_per_cycle: Option<Amount>,
     /// Maximum price per cycle (e.g., "0.00001 USD", "0.0000001 ETH").
     /// If unset, the SDK default (~100 Kwei/cycle, 99th percentile) is used.
     #[clap(
@@ -159,10 +159,10 @@ pub struct MarketProviderConfig {
         required = false,
         conflicts_with = "boundless_legacy_pricing"
     )]
-    pub boundless_max_price_per_cycle: Option<String>,
+    pub boundless_max_price_per_cycle: Option<Amount>,
     /// Hard cap on total order price (e.g., "0.5 ETH", "100 USD"). Safety mechanism.
     #[clap(long, env, required = false)]
-    pub boundless_max_price_cap: Option<String>,
+    pub boundless_max_price_cap: Option<Amount>,
 
     /// How much % to increase the price of the proving order by after it expires.
     #[clap(long, env, required = false, default_value_t = 10)]
@@ -406,17 +406,20 @@ impl MarketProviderConfig {
         if let Some(ref min_price) = self.boundless_min_price_per_cycle {
             proving_args.extend(vec![
                 String::from("--boundless-min-price-per-cycle"),
-                min_price.clone(),
+                min_price.to_string(),
             ]);
         }
         if let Some(ref max_price) = self.boundless_max_price_per_cycle {
             proving_args.extend(vec![
                 String::from("--boundless-max-price-per-cycle"),
-                max_price.clone(),
+                max_price.to_string(),
             ]);
         }
         if let Some(ref cap) = self.boundless_max_price_cap {
-            proving_args.extend(vec![String::from("--boundless-max-price-cap"), cap.clone()]);
+            proving_args.extend(vec![
+                String::from("--boundless-max-price-cap"),
+                cap.to_string(),
+            ]);
         }
         if self.boundless_legacy_pricing {
             proving_args.extend(vec![
@@ -617,26 +620,11 @@ pub async fn run_boundless_client<A: NoUninit + Into<Digest>>(
             .with_uploader(Some(storage_provider.clone()))
             .with_funding_mode(market.funding_mode())
             .config_offer_layer(|config| {
-                // Set per-cycle price overrides if provided; otherwise SDK uses market prices or built-in defaults.
                 if let Some(ref min_price) = market.boundless_min_price_per_cycle {
-                    if let Ok(amount) = Amount::parse(min_price, None) {
-                        config.min_price_per_cycle(amount);
-                    } else {
-                        tracing::warn!(
-                            "Failed to parse --boundless-min-price-per-cycle '{}', using SDK default",
-                            min_price
-                        );
-                    }
+                    config.min_price_per_cycle(min_price.clone());
                 }
                 if let Some(ref max_price) = market.boundless_max_price_per_cycle {
-                    if let Ok(amount) = Amount::parse(max_price, None) {
-                        config.max_price_per_cycle(amount);
-                    } else {
-                        tracing::warn!(
-                            "Failed to parse --boundless-max-price-per-cycle '{}', using SDK default",
-                            max_price
-                        );
-                    }
+                    config.max_price_per_cycle(max_price.clone());
                 }
                 config
             })
@@ -1374,17 +1362,13 @@ pub async fn request_proof<A: NoUninit + Into<Digest>>(
     }
 
     // Apply max_price_cap safety (both paths)
-    if let Some(ref cap_str) = market.boundless_max_price_cap {
-        if let Ok(cap) = Amount::parse(cap_str, None) {
-            if request.offer.maxPrice > cap.value {
-                warn!(
-                    "maxPrice {} exceeds cap {}, capping",
-                    request.offer.maxPrice, cap_str
-                );
-                request.offer.maxPrice = cap.value;
-            }
-        } else {
-            warn!("Failed to parse --boundless-max-price-cap '{}'", cap_str);
+    if let Some(ref cap) = market.boundless_max_price_cap {
+        if request.offer.maxPrice > cap.value {
+            warn!(
+                "maxPrice {} exceeds cap {}, capping",
+                request.offer.maxPrice, cap
+            );
+            request.offer.maxPrice = cap.value;
         }
     }
 


### PR DESCRIPTION
Replace static wei-based pricing in `request_proof()` with the Boundless SDK's `OfferLayer` via `build_request()`.

- Upgrade `boundless-market` to 1.4
- New CLI flags: `--boundless-min-price-per-cycle`, `--boundless-max-price-per-cycle`, `--boundless-max-price-cap`
- SDK handles pricing from market data + gas costs, timing from `ParameterizationMode`, collateral from chain defaults
- Legacy pricing preserved behind `--boundless-legacy-pricing` flag
- Retry escalation applied post-build for both paths
- Docs updated in `book/src/validator.md`