### PR TITLE
Use risc0-crypto-backed revm precompile implementations in guest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1209,7 +1209,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1220,7 +1220,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2436,7 +2436,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -3946,7 +3946,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4312,7 +4312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8328,7 +8328,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8475,7 +8475,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11090,8 +11090,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-crypto"
-version = "0.1.0"
-source = "git+https://github.com/boundless-xyz/risc0-crypto?rev=92de69e3732b0a59cc1f843d72d7ef2c8ccc7e64#92de69e3732b0a59cc1f843d72d7ef2c8ccc7e64"
+version = "0.1.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66597cf3daedbb967414c9c68ab603cccefe4d917b2834edad346bb2414d8247"
 dependencies = [
  "bytemuck",
  "cargo_metadata 0.23.1",
@@ -11102,8 +11103,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-crypto-evm"
-version = "0.1.0"
-source = "git+https://github.com/boundless-xyz/risc0-crypto?rev=92de69e3732b0a59cc1f843d72d7ef2c8ccc7e64#92de69e3732b0a59cc1f843d72d7ef2c8ccc7e64"
+version = "0.1.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcd8062563b5737d4e160ebf71819df2b6a9604b1d4e226df461ad36a1ca25df"
 dependencies = [
  "alloy-primitives 1.5.7",
  "risc0-crypto",
@@ -11607,7 +11609,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11620,7 +11622,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11691,7 +11693,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11712,7 +11714,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12358,7 +12360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12570,7 +12572,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "url",
  "zip 4.6.1",
 ]
@@ -12708,7 +12710,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14020,7 +14022,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2905,13 +2905,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-platform"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "cargo_metadata"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.1.9",
+ "semver 1.0.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform 0.3.3",
  "semver 1.0.28",
  "serde",
  "serde_json",
@@ -6077,6 +6101,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee796ad498c8d9a1d68e477df8f754ed784ef875de1414ebdaf169f70a6a784"
 
 [[package]]
+name = "include_bytes_aligned"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb3f0fd7913f9257b6862075640a029db0fff0887a3f49e00059f52b7111cf11"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6772,6 +6802,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.23",
+ "zeth-r0vm-precompile",
 ]
 
 [[package]]
@@ -10849,6 +10880,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-bigint2"
+version = "1.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af3997ed5c8a35afd2fa39055f1b841e19571379e55ee634a06c41d7b924052d"
+dependencies = [
+ "include_bytes_aligned 0.1.4",
+ "stability",
+]
+
+[[package]]
 name = "risc0-binfmt"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10877,7 +10918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89937fa1c424b188cc4cabf65335736eca9c1e3df79c127f48636f55682f3a4"
 dependencies = [
  "anyhow",
- "cargo_metadata",
+ "cargo_metadata 0.19.2",
  "derive_builder",
  "dirs 6.0.0",
  "docker-generate",
@@ -11048,6 +11089,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-crypto"
+version = "0.1.0"
+source = "git+https://github.com/Wollac/risc0-crypto?rev=320a9dfe61fe0ffc1ff2f732d894dfa9647a188c#320a9dfe61fe0ffc1ff2f732d894dfa9647a188c"
+dependencies = [
+ "bytemuck",
+ "cargo_metadata 0.23.1",
+ "educe",
+ "include_bytes_aligned 0.2.0",
+ "risc0-bigint2",
+]
+
+[[package]]
 name = "risc0-ethereum-contracts"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11155,7 +11208,7 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bd70cb45b5d37d025f25663b87c6b9dc9df7f413ee2068531a57f50b0eb95db"
 dependencies = [
- "include_bytes_aligned",
+ "include_bytes_aligned 0.1.4",
  "no_std_strings",
  "risc0-zkvm-platform",
 ]
@@ -14689,6 +14742,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zeth-r0vm-precompile"
+version = "0.3.0"
+source = "git+https://github.com/boundless-xyz/zeth?rev=d40b4f1f57e656cce7853224563f94c1f6994db3#d40b4f1f57e656cce7853224563f94c1f6994db3"
+dependencies = [
+ "alloy-primitives 1.5.7",
+ "risc0-crypto",
+ "risc0-zkp",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1209,7 +1209,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1220,7 +1220,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2436,7 +2436,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -3946,7 +3946,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4312,7 +4312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6793,6 +6793,7 @@ dependencies = [
  "op-alloy-rpc-types-engine",
  "pot",
  "rayon",
+ "risc0-crypto-evm",
  "risc0-zkvm",
  "rkyv",
  "serde",
@@ -6802,7 +6803,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.23",
- "zeth-r0vm-precompile",
 ]
 
 [[package]]
@@ -8328,7 +8328,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8475,7 +8475,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11091,13 +11091,23 @@ dependencies = [
 [[package]]
 name = "risc0-crypto"
 version = "0.1.0"
-source = "git+https://github.com/Wollac/risc0-crypto?rev=320a9dfe61fe0ffc1ff2f732d894dfa9647a188c#320a9dfe61fe0ffc1ff2f732d894dfa9647a188c"
+source = "git+https://github.com/boundless-xyz/risc0-crypto?rev=92de69e3732b0a59cc1f843d72d7ef2c8ccc7e64#92de69e3732b0a59cc1f843d72d7ef2c8ccc7e64"
 dependencies = [
  "bytemuck",
  "cargo_metadata 0.23.1",
  "educe",
  "include_bytes_aligned 0.2.0",
  "risc0-bigint2",
+]
+
+[[package]]
+name = "risc0-crypto-evm"
+version = "0.1.0"
+source = "git+https://github.com/boundless-xyz/risc0-crypto?rev=92de69e3732b0a59cc1f843d72d7ef2c8ccc7e64#92de69e3732b0a59cc1f843d72d7ef2c8ccc7e64"
+dependencies = [
+ "alloy-primitives 1.5.7",
+ "risc0-crypto",
+ "risc0-zkp",
 ]
 
 [[package]]
@@ -11597,7 +11607,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11610,7 +11620,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11681,7 +11691,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11702,7 +11712,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12348,7 +12358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12560,7 +12570,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "url",
  "zip 4.6.1",
 ]
@@ -12698,7 +12708,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14010,7 +14020,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -14742,16 +14752,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "zeth-r0vm-precompile"
-version = "0.3.0"
-source = "git+https://github.com/boundless-xyz/zeth?rev=d40b4f1f57e656cce7853224563f94c1f6994db3#d40b4f1f57e656cce7853224563f94c1f6994db3"
-dependencies = [
- "alloy-primitives 1.5.7",
- "risc0-crypto",
- "risc0-zkp",
 ]
 
 [[package]]

--- a/bin/cli/Cargo.toml
+++ b/bin/cli/Cargo.toml
@@ -30,7 +30,7 @@ tracing.workspace = true
 
 opentelemetry.workspace = true
 
-alloy = { workspace = true, features = ["full", "kzg", "signer-aws", "signer-gcp"] }
+alloy = { workspace = true, features = ["full", "kzg", "signer-aws", "signer-gcp", "signer-local"] }
 
 kailua-build.workspace = true
 kailua-kona.workspace = true

--- a/bin/cli/tests/devnet.rs
+++ b/bin/cli/tests/devnet.rs
@@ -629,6 +629,7 @@ fn base_proving_args(max_witness_size: usize) -> ProvingArgs {
         #[cfg(feature = "celestia")]
         hana: Default::default(),
         export_profile_csv: false,
+        enable_experimental_r0vm_crypto: false,
     }
 }
 

--- a/bin/cli/tests/devnet.rs
+++ b/bin/cli/tests/devnet.rs
@@ -633,6 +633,40 @@ fn base_proving_args(max_witness_size: usize) -> ProvingArgs {
     }
 }
 
+/// Fires a single L2 tx whose `to` is the SHA256 precompile (0x02). Sending a tx
+/// directly to a precompile address invokes the precompile via the EVM call frame,
+/// which is the only way revm's `Crypto::sha256` is reached. Used to verify that
+/// the experimental R0VM crypto provider is actually exercised end-to-end on the
+/// devnet (which otherwise produces only L1-attributes deposit txs that touch no
+/// precompiles).
+///
+/// The signing account is the standard hardhat dev mnemonic account #0, which is
+/// prefunded on the L2 by `fund_dev_accounts: true` in `kurtosis.yaml`.
+async fn fire_precompile_probe_tx(devnet: &DevnetConfig) -> anyhow::Result<()> {
+    use alloy::network::TransactionBuilder;
+    use alloy::primitives::{address, Bytes};
+    use alloy::providers::ProviderBuilder;
+    use alloy::rpc::types::TransactionRequest;
+    use alloy::signers::local::PrivateKeySigner;
+
+    const DEV_PRIV_KEY: &str =
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+    let signer: PrivateKeySigner = DEV_PRIV_KEY.parse()?;
+    let l2_url = devnet.l2_rpc_url()?.parse()?;
+    let provider = ProviderBuilder::new().wallet(signer).connect_http(l2_url);
+
+    let tx = TransactionRequest::default()
+        .with_to(address!("0x0000000000000000000000000000000000000002"))
+        .with_input(Bytes::from_static(b"r0vm-crypto-probe"));
+    let receipt = provider.send_transaction(tx).await?.get_receipt().await?;
+    println!(
+        "Precompile probe (sha256) included in L2 block #{:?}, tx {:?}",
+        receipt.block_number, receipt.transaction_hash
+    );
+    Ok(())
+}
+
 async fn run_prover(
     devnet: &DevnetConfig,
     proof_size: u64,
@@ -962,9 +996,11 @@ async fn prover() {
     // update dgf to use kailua
     deploy_kailua_contracts(&devnet, 60).await.unwrap();
 
-    run_prover(&devnet, PROOF_SIZE, base_proving_args(5 * 1024 * 1024))
-        .await
-        .unwrap();
+    fire_precompile_probe_tx(&devnet).await.unwrap();
+
+    let mut proving = base_proving_args(5 * 1024 * 1024);
+    proving.enable_experimental_r0vm_crypto = true;
+    run_prover(&devnet, PROOF_SIZE, proving).await.unwrap();
 
     // Stop and discard the devnet
     stop_all_devnets().await;

--- a/book/src/validator.md
+++ b/book/src/validator.md
@@ -72,6 +72,7 @@ The validator proving behavior can be customized through the following arguments
 * `max-block-executions`: Maximum number of blocks to execute per single proof.
 * `num-tail-blocks`: Rate of growth of tail proofs in L1 blocks (Default 10).
 * `enable-experimental-witness-endpoint`: Enables the use of `debug_executePayload` to collect the execution witness from the execution layer.
+* `enable-experimental-r0vm-crypto`: Opts in to the R0VM-accelerated revm `Crypto` provider for EVM precompiles. Off by default until `risc0-crypto` has been fully audited.
 * `max-fault-proving-delay`: The maximum amount of seconds to wait before starting to compute a fault proof (Default 900).
 * `max-validity-proving-delay`: The maximum amount of seconds to wait before starting to compute a validity proof (Default 0).
 * `clear-cache-data`: Whether to clear cache data after successful completion (Default false).

--- a/build/risczero/hana/Cargo.lock
+++ b/build/risczero/hana/Cargo.lock
@@ -3276,13 +3276,13 @@ dependencies = [
  "op-alloy-consensus 0.23.1",
  "op-alloy-rpc-types-engine",
  "pot",
+ "risc0-crypto-evm",
  "risc0-zkvm",
  "rkyv",
  "serde",
  "serde_json",
  "spin 0.10.0",
  "tracing",
- "zeth-r0vm-precompile",
 ]
 
 [[package]]
@@ -5561,13 +5561,23 @@ dependencies = [
 [[package]]
 name = "risc0-crypto"
 version = "0.1.0"
-source = "git+https://github.com/Wollac/risc0-crypto?rev=320a9dfe61fe0ffc1ff2f732d894dfa9647a188c#320a9dfe61fe0ffc1ff2f732d894dfa9647a188c"
+source = "git+https://github.com/boundless-xyz/risc0-crypto?rev=92de69e3732b0a59cc1f843d72d7ef2c8ccc7e64#92de69e3732b0a59cc1f843d72d7ef2c8ccc7e64"
 dependencies = [
  "bytemuck",
  "cargo_metadata 0.23.1",
  "educe",
  "include_bytes_aligned 0.2.0",
  "risc0-bigint2",
+]
+
+[[package]]
+name = "risc0-crypto-evm"
+version = "0.1.0"
+source = "git+https://github.com/boundless-xyz/risc0-crypto?rev=92de69e3732b0a59cc1f843d72d7ef2c8ccc7e64#92de69e3732b0a59cc1f843d72d7ef2c8ccc7e64"
+dependencies = [
+ "alloy-primitives",
+ "risc0-crypto",
+ "risc0-zkp",
 ]
 
 [[package]]
@@ -7692,16 +7702,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "zeth-r0vm-precompile"
-version = "0.3.0"
-source = "git+https://github.com/boundless-xyz/zeth?rev=d40b4f1f57e656cce7853224563f94c1f6994db3#d40b4f1f57e656cce7853224563f94c1f6994db3"
-dependencies = [
- "alloy-primitives",
- "risc0-crypto",
- "risc0-zkp",
 ]
 
 [[package]]

--- a/build/risczero/hana/Cargo.lock
+++ b/build/risczero/hana/Cargo.lock
@@ -1557,13 +1557,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-platform"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "cargo_metadata"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.1.9",
+ "semver 1.0.28",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform 0.3.3",
  "semver 1.0.28",
  "serde",
  "serde_json",
@@ -3071,6 +3095,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee796ad498c8d9a1d68e477df8f754ed784ef875de1414ebdaf169f70a6a784"
 
 [[package]]
+name = "include_bytes_aligned"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb3f0fd7913f9257b6862075640a029db0fff0887a3f49e00059f52b7111cf11"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3252,6 +3282,7 @@ dependencies = [
  "serde_json",
  "spin 0.10.0",
  "tracing",
+ "zeth-r0vm-precompile",
 ]
 
 [[package]]
@@ -5418,7 +5449,7 @@ version = "1.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af3997ed5c8a35afd2fa39055f1b841e19571379e55ee634a06c41d7b924052d"
 dependencies = [
- "include_bytes_aligned",
+ "include_bytes_aligned 0.1.4",
  "stability",
 ]
 
@@ -5451,7 +5482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89937fa1c424b188cc4cabf65335736eca9c1e3df79c127f48636f55682f3a4"
 dependencies = [
  "anyhow",
- "cargo_metadata",
+ "cargo_metadata 0.19.2",
  "derive_builder",
  "dirs",
  "docker-generate",
@@ -5528,6 +5559,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-crypto"
+version = "0.1.0"
+source = "git+https://github.com/Wollac/risc0-crypto?rev=320a9dfe61fe0ffc1ff2f732d894dfa9647a188c#320a9dfe61fe0ffc1ff2f732d894dfa9647a188c"
+dependencies = [
+ "bytemuck",
+ "cargo_metadata 0.23.1",
+ "educe",
+ "include_bytes_aligned 0.2.0",
+ "risc0-bigint2",
+]
+
+[[package]]
 name = "risc0-groth16"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5576,7 +5619,7 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bd70cb45b5d37d025f25663b87c6b9dc9df7f413ee2068531a57f50b0eb95db"
 dependencies = [
- "include_bytes_aligned",
+ "include_bytes_aligned 0.1.4",
  "no_std_strings",
  "risc0-zkvm-platform",
 ]
@@ -7649,6 +7692,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zeth-r0vm-precompile"
+version = "0.3.0"
+source = "git+https://github.com/boundless-xyz/zeth?rev=d40b4f1f57e656cce7853224563f94c1f6994db3#d40b4f1f57e656cce7853224563f94c1f6994db3"
+dependencies = [
+ "alloy-primitives",
+ "risc0-crypto",
+ "risc0-zkp",
 ]
 
 [[package]]

--- a/build/risczero/hokulea/Cargo.lock
+++ b/build/risczero/hokulea/Cargo.lock
@@ -1373,13 +1373,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-platform"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "cargo_metadata"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.1.9",
+ "semver 1.0.28",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform 0.3.3",
  "semver 1.0.28",
  "serde",
  "serde_json",
@@ -2681,6 +2705,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee796ad498c8d9a1d68e477df8f754ed784ef875de1414ebdaf169f70a6a784"
 
 [[package]]
+name = "include_bytes_aligned"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb3f0fd7913f9257b6862075640a029db0fff0887a3f49e00059f52b7111cf11"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2866,6 +2896,7 @@ dependencies = [
  "serde_json",
  "spin 0.10.0",
  "tracing",
+ "zeth-r0vm-precompile",
 ]
 
 [[package]]
@@ -5142,7 +5173,7 @@ version = "1.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af3997ed5c8a35afd2fa39055f1b841e19571379e55ee634a06c41d7b924052d"
 dependencies = [
- "include_bytes_aligned",
+ "include_bytes_aligned 0.1.4",
  "stability",
 ]
 
@@ -5175,7 +5206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89937fa1c424b188cc4cabf65335736eca9c1e3df79c127f48636f55682f3a4"
 dependencies = [
  "anyhow",
- "cargo_metadata",
+ "cargo_metadata 0.19.2",
  "derive_builder",
  "dirs",
  "docker-generate",
@@ -5252,6 +5283,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-crypto"
+version = "0.1.0"
+source = "git+https://github.com/Wollac/risc0-crypto?rev=320a9dfe61fe0ffc1ff2f732d894dfa9647a188c#320a9dfe61fe0ffc1ff2f732d894dfa9647a188c"
+dependencies = [
+ "bytemuck",
+ "cargo_metadata 0.23.1",
+ "educe",
+ "include_bytes_aligned 0.2.0",
+ "risc0-bigint2",
+]
+
+[[package]]
 name = "risc0-groth16"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5300,7 +5343,7 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bd70cb45b5d37d025f25663b87c6b9dc9df7f413ee2068531a57f50b0eb95db"
 dependencies = [
- "include_bytes_aligned",
+ "include_bytes_aligned 0.1.4",
  "no_std_strings",
  "risc0-zkvm-platform",
 ]
@@ -7283,6 +7326,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zeth-r0vm-precompile"
+version = "0.3.0"
+source = "git+https://github.com/boundless-xyz/zeth?rev=d40b4f1f57e656cce7853224563f94c1f6994db3#d40b4f1f57e656cce7853224563f94c1f6994db3"
+dependencies = [
+ "alloy-primitives",
+ "risc0-crypto",
+ "risc0-zkp",
 ]
 
 [[package]]

--- a/build/risczero/hokulea/Cargo.lock
+++ b/build/risczero/hokulea/Cargo.lock
@@ -2890,13 +2890,13 @@ dependencies = [
  "op-alloy-consensus 0.23.1",
  "op-alloy-rpc-types-engine",
  "pot",
+ "risc0-crypto-evm",
  "risc0-zkvm",
  "rkyv",
  "serde",
  "serde_json",
  "spin 0.10.0",
  "tracing",
- "zeth-r0vm-precompile",
 ]
 
 [[package]]
@@ -5285,13 +5285,23 @@ dependencies = [
 [[package]]
 name = "risc0-crypto"
 version = "0.1.0"
-source = "git+https://github.com/Wollac/risc0-crypto?rev=320a9dfe61fe0ffc1ff2f732d894dfa9647a188c#320a9dfe61fe0ffc1ff2f732d894dfa9647a188c"
+source = "git+https://github.com/boundless-xyz/risc0-crypto?rev=92de69e3732b0a59cc1f843d72d7ef2c8ccc7e64#92de69e3732b0a59cc1f843d72d7ef2c8ccc7e64"
 dependencies = [
  "bytemuck",
  "cargo_metadata 0.23.1",
  "educe",
  "include_bytes_aligned 0.2.0",
  "risc0-bigint2",
+]
+
+[[package]]
+name = "risc0-crypto-evm"
+version = "0.1.0"
+source = "git+https://github.com/boundless-xyz/risc0-crypto?rev=92de69e3732b0a59cc1f843d72d7ef2c8ccc7e64#92de69e3732b0a59cc1f843d72d7ef2c8ccc7e64"
+dependencies = [
+ "alloy-primitives",
+ "risc0-crypto",
+ "risc0-zkp",
 ]
 
 [[package]]
@@ -7326,16 +7336,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "zeth-r0vm-precompile"
-version = "0.3.0"
-source = "git+https://github.com/boundless-xyz/zeth?rev=d40b4f1f57e656cce7853224563f94c1f6994db3#d40b4f1f57e656cce7853224563f94c1f6994db3"
-dependencies = [
- "alloy-primitives",
- "risc0-crypto",
- "risc0-zkp",
 ]
 
 [[package]]

--- a/build/risczero/kona/Cargo.lock
+++ b/build/risczero/kona/Cargo.lock
@@ -1189,13 +1189,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-platform"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "cargo_metadata"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.1.9",
+ "semver 1.0.28",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform 0.3.3",
  "semver 1.0.28",
  "serde",
  "serde_json",
@@ -2406,6 +2430,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee796ad498c8d9a1d68e477df8f754ed784ef875de1414ebdaf169f70a6a784"
 
 [[package]]
+name = "include_bytes_aligned"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb3f0fd7913f9257b6862075640a029db0fff0887a3f49e00059f52b7111cf11"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2551,6 +2581,7 @@ dependencies = [
  "serde_json",
  "spin 0.10.0",
  "tracing",
+ "zeth-r0vm-precompile",
 ]
 
 [[package]]
@@ -4089,7 +4120,7 @@ version = "1.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af3997ed5c8a35afd2fa39055f1b841e19571379e55ee634a06c41d7b924052d"
 dependencies = [
- "include_bytes_aligned",
+ "include_bytes_aligned 0.1.4",
  "stability",
 ]
 
@@ -4122,7 +4153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89937fa1c424b188cc4cabf65335736eca9c1e3df79c127f48636f55682f3a4"
 dependencies = [
  "anyhow",
- "cargo_metadata",
+ "cargo_metadata 0.19.2",
  "derive_builder",
  "dirs",
  "docker-generate",
@@ -4199,6 +4230,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-crypto"
+version = "0.1.0"
+source = "git+https://github.com/Wollac/risc0-crypto?rev=320a9dfe61fe0ffc1ff2f732d894dfa9647a188c#320a9dfe61fe0ffc1ff2f732d894dfa9647a188c"
+dependencies = [
+ "bytemuck",
+ "cargo_metadata 0.23.1",
+ "educe",
+ "include_bytes_aligned 0.2.0",
+ "risc0-bigint2",
+]
+
+[[package]]
 name = "risc0-groth16"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4225,7 +4268,7 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bd70cb45b5d37d025f25663b87c6b9dc9df7f413ee2068531a57f50b0eb95db"
 dependencies = [
- "include_bytes_aligned",
+ "include_bytes_aligned 0.1.4",
  "no_std_strings",
  "risc0-zkvm-platform",
 ]
@@ -6119,6 +6162,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zeth-r0vm-precompile"
+version = "0.3.0"
+source = "git+https://github.com/boundless-xyz/zeth?rev=d40b4f1f57e656cce7853224563f94c1f6994db3#d40b4f1f57e656cce7853224563f94c1f6994db3"
+dependencies = [
+ "alloy-primitives",
+ "risc0-crypto",
+ "risc0-zkp",
 ]
 
 [[package]]

--- a/build/risczero/kona/Cargo.lock
+++ b/build/risczero/kona/Cargo.lock
@@ -2575,13 +2575,13 @@ dependencies = [
  "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
  "pot",
+ "risc0-crypto-evm",
  "risc0-zkvm",
  "rkyv",
  "serde",
  "serde_json",
  "spin 0.10.0",
  "tracing",
- "zeth-r0vm-precompile",
 ]
 
 [[package]]
@@ -4232,13 +4232,23 @@ dependencies = [
 [[package]]
 name = "risc0-crypto"
 version = "0.1.0"
-source = "git+https://github.com/Wollac/risc0-crypto?rev=320a9dfe61fe0ffc1ff2f732d894dfa9647a188c#320a9dfe61fe0ffc1ff2f732d894dfa9647a188c"
+source = "git+https://github.com/boundless-xyz/risc0-crypto?rev=92de69e3732b0a59cc1f843d72d7ef2c8ccc7e64#92de69e3732b0a59cc1f843d72d7ef2c8ccc7e64"
 dependencies = [
  "bytemuck",
  "cargo_metadata 0.23.1",
  "educe",
  "include_bytes_aligned 0.2.0",
  "risc0-bigint2",
+]
+
+[[package]]
+name = "risc0-crypto-evm"
+version = "0.1.0"
+source = "git+https://github.com/boundless-xyz/risc0-crypto?rev=92de69e3732b0a59cc1f843d72d7ef2c8ccc7e64#92de69e3732b0a59cc1f843d72d7ef2c8ccc7e64"
+dependencies = [
+ "alloy-primitives",
+ "risc0-crypto",
+ "risc0-zkp",
 ]
 
 [[package]]
@@ -6162,16 +6172,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "zeth-r0vm-precompile"
-version = "0.3.0"
-source = "git+https://github.com/boundless-xyz/zeth?rev=d40b4f1f57e656cce7853224563f94c1f6994db3#d40b4f1f57e656cce7853224563f94c1f6994db3"
-dependencies = [
- "alloy-primitives",
- "risc0-crypto",
- "risc0-zkp",
 ]
 
 [[package]]

--- a/crates/kona/Cargo.toml
+++ b/crates/kona/Cargo.toml
@@ -47,7 +47,7 @@ kona-protocol.workspace = true
 risc0-zkvm.workspace = true
 
 [target.'cfg(all(target_os = "zkvm", target_vendor = "risc0"))'.dependencies]
-risc0-crypto-evm = { git = "https://github.com/boundless-xyz/risc0-crypto", rev = "92de69e3732b0a59cc1f843d72d7ef2c8ccc7e64" }
+risc0-crypto-evm = "=0.1.0-rc.1"
 
 [dev-dependencies]
 alloy = { workspace = true, features = ["genesis"] }

--- a/crates/kona/Cargo.toml
+++ b/crates/kona/Cargo.toml
@@ -47,10 +47,7 @@ kona-protocol.workspace = true
 risc0-zkvm.workspace = true
 
 [target.'cfg(all(target_os = "zkvm", target_vendor = "risc0"))'.dependencies]
-# R0VM-accelerated EVM precompile primitives. The `zeth-r0vm-precompile` crate
-# wraps `risc0-crypto` in plain functions (no revm dep), keeping this adapter
-# independent of which revm version zeth's consumers happen to be on.
-zeth-r0vm-precompile = { git = "https://github.com/boundless-xyz/zeth", rev = "d40b4f1f57e656cce7853224563f94c1f6994db3" }
+risc0-crypto-evm = { git = "https://github.com/boundless-xyz/risc0-crypto", rev = "92de69e3732b0a59cc1f843d72d7ef2c8ccc7e64" }
 
 [dev-dependencies]
 alloy = { workspace = true, features = ["genesis"] }

--- a/crates/kona/Cargo.toml
+++ b/crates/kona/Cargo.toml
@@ -46,6 +46,12 @@ kona-protocol.workspace = true
 
 risc0-zkvm.workspace = true
 
+[target.'cfg(all(target_os = "zkvm", target_vendor = "risc0"))'.dependencies]
+# R0VM-accelerated EVM precompile primitives. The `zeth-r0vm-precompile` crate
+# wraps `risc0-crypto` in plain functions (no revm dep), keeping this adapter
+# independent of which revm version zeth's consumers happen to be on.
+zeth-r0vm-precompile = { git = "https://github.com/boundless-xyz/zeth", rev = "d40b4f1f57e656cce7853224563f94c1f6994db3" }
+
 [dev-dependencies]
 alloy = { workspace = true, features = ["genesis"] }
 copy_dir.workspace = true

--- a/crates/kona/src/client/stateless.rs
+++ b/crates/kona/src/client/stateless.rs
@@ -52,6 +52,11 @@ pub fn run_stateless_client<O: WitnessOracle, S: StitchingClient<O, PreloadedBlo
     witness: Witness<O>,
     stitching_client: S,
 ) -> ProofJournal {
+    // Install the R0VM-accelerated revm Crypto provider for EVM precompiles.
+    // Only compiled on the zkvm target; host tests keep DefaultCrypto.
+    #[cfg(all(target_os = "zkvm", target_vendor = "risc0"))]
+    crate::crypto::install_r0vm_crypto();
+
     log(&format!(
         "ORACLE: {} PREIMAGES",
         witness.oracle_witness.preimage_count()

--- a/crates/kona/src/client/stateless.rs
+++ b/crates/kona/src/client/stateless.rs
@@ -55,7 +55,7 @@ pub fn run_stateless_client<O: WitnessOracle, S: StitchingClient<O, PreloadedBlo
     // Install the R0VM-accelerated revm Crypto provider for EVM precompiles.
     // Only compiled on the zkvm target; host tests keep DefaultCrypto.
     #[cfg(all(target_os = "zkvm", target_vendor = "risc0"))]
-    crate::crypto::install_r0vm_crypto();
+    crate::r0vm_crypto::install_r0vm_crypto();
 
     log(&format!(
         "ORACLE: {} PREIMAGES",

--- a/crates/kona/src/client/stateless.rs
+++ b/crates/kona/src/client/stateless.rs
@@ -52,10 +52,11 @@ pub fn run_stateless_client<O: WitnessOracle, S: StitchingClient<O, PreloadedBlo
     witness: Witness<O>,
     stitching_client: S,
 ) -> ProofJournal {
-    // Install the R0VM-accelerated revm Crypto provider for EVM precompiles.
-    // Only compiled on the zkvm target; host tests keep DefaultCrypto.
+    // Opt-in: experimental R0VM-accelerated Crypto provider; otherwise DefaultCrypto.
     #[cfg(all(target_os = "zkvm", target_vendor = "risc0"))]
-    crate::r0vm_crypto::install_r0vm_crypto();
+    if witness.enable_experimental_r0vm_crypto {
+        crate::r0vm_crypto::install_r0vm_crypto();
+    }
 
     log(&format!(
         "ORACLE: {} PREIMAGES",
@@ -142,6 +143,7 @@ pub mod tests {
             stitched_preconditions: vec![],
             stitched_boot_info: vec![],
             fpvm_image_id: Default::default(),
+            enable_experimental_r0vm_crypto: false,
         };
 
         run_stateless_client(witness, KonaStitchingClient(EthereumDataSourceProvider));

--- a/crates/kona/src/crypto.rs
+++ b/crates/kona/src/crypto.rs
@@ -1,0 +1,98 @@
+// Copyright 2024, 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! revm `Crypto` adapter over the primitives in `zeth-r0vm-precompile`.
+//!
+//! The adapter routes `sha256`, `modexp`, `bn254_g1_{add,mul}`,
+//! `secp256r1_verify_signature`, and `secp256k1_ecrecover` through
+//! [`zeth_r0vm_precompile`]. All other `Crypto` methods fall through to
+//! `DefaultCrypto`.
+//!
+//! [`install_r0vm_crypto`] is only defined on the zkVM target — calling it
+//! from host code is a compile error, not a silent no-op. Callers gate the
+//! install point with the same `cfg` attribute. Revm types are pulled in via
+//! `alloy_evm::revm::precompile` so the install targets the same global
+//! `OnceLock` that the EVM executor uses.
+
+#![cfg(all(target_os = "zkvm", target_vendor = "risc0"))]
+
+/// Installs the R0VM-accelerated crypto provider globally.
+///
+/// Returns `true` if this call installed the provider, `false` if a provider
+/// was already installed (the revm `OnceLock` only accepts the first write).
+#[inline]
+pub fn install_r0vm_crypto() -> bool {
+    alloy_evm::revm::precompile::install_crypto(R0vmCrypto)
+}
+
+#[derive(Debug, Clone, Default)]
+struct R0vmCrypto;
+
+impl alloy_evm::revm::precompile::Crypto for R0vmCrypto {
+    #[inline]
+    fn sha256(&self, input: &[u8]) -> [u8; 32] {
+        zeth_r0vm_precompile::sha256(input)
+    }
+
+    #[inline]
+    fn modexp(
+        &self,
+        base: &[u8],
+        exp: &[u8],
+        modulus: &[u8],
+    ) -> Result<Vec<u8>, alloy_evm::revm::precompile::PrecompileError> {
+        use alloy_evm::revm::precompile::{Crypto, DefaultCrypto};
+        match zeth_r0vm_precompile::modexp(base, exp, modulus) {
+            Some(out) => Ok(out),
+            None => DefaultCrypto.modexp(base, exp, modulus),
+        }
+    }
+
+    #[inline]
+    fn bn254_g1_add(
+        &self,
+        p1: &[u8],
+        p2: &[u8],
+    ) -> Result<[u8; 64], alloy_evm::revm::precompile::PrecompileError> {
+        zeth_r0vm_precompile::bn254_g1_add(p1, p2)
+            .ok_or(alloy_evm::revm::precompile::PrecompileError::Bn254AffineGFailedToCreate)
+    }
+
+    #[inline]
+    fn bn254_g1_mul(
+        &self,
+        point: &[u8],
+        scalar: &[u8],
+    ) -> Result<[u8; 64], alloy_evm::revm::precompile::PrecompileError> {
+        zeth_r0vm_precompile::bn254_g1_mul(point, scalar)
+            .ok_or(alloy_evm::revm::precompile::PrecompileError::Bn254AffineGFailedToCreate)
+    }
+
+    #[inline]
+    fn secp256r1_verify_signature(&self, msg: &[u8; 32], sig: &[u8; 64], pk: &[u8; 64]) -> bool {
+        zeth_r0vm_precompile::secp256r1_verify(msg, sig, pk)
+    }
+
+    #[inline]
+    fn secp256k1_ecrecover(
+        &self,
+        sig: &[u8; 64],
+        recid: u8,
+        msg: &[u8; 32],
+    ) -> Result<[u8; 32], alloy_evm::revm::precompile::PrecompileError> {
+        zeth_r0vm_precompile::secp256k1_ecrecover(sig, recid, msg)
+            .map(|addr| addr.into_word().0)
+            .ok_or(alloy_evm::revm::precompile::PrecompileError::Secp256k1RecoverFailed)
+    }
+}

--- a/crates/kona/src/lib.rs
+++ b/crates/kona/src/lib.rs
@@ -25,7 +25,7 @@ pub mod client;
 /// Procedures for generating secure cryptographic commitments to rollup configuration settings.
 pub mod config;
 /// R0VM-accelerated revm `Crypto` provider for EVM precompiles.
-pub mod crypto;
+pub mod r0vm_crypto;
 /// Implementation for caching support in derivation.
 pub mod driver;
 /// Implementation for an execution engine with caching support.

--- a/crates/kona/src/lib.rs
+++ b/crates/kona/src/lib.rs
@@ -24,6 +24,8 @@ pub mod boot;
 pub mod client;
 /// Procedures for generating secure cryptographic commitments to rollup configuration settings.
 pub mod config;
+/// R0VM-accelerated revm `Crypto` provider for EVM precompiles.
+pub mod crypto;
 /// Implementation for caching support in derivation.
 pub mod driver;
 /// Implementation for an execution engine with caching support.

--- a/crates/kona/src/lib.rs
+++ b/crates/kona/src/lib.rs
@@ -24,8 +24,6 @@ pub mod boot;
 pub mod client;
 /// Procedures for generating secure cryptographic commitments to rollup configuration settings.
 pub mod config;
-/// R0VM-accelerated revm `Crypto` provider for EVM precompiles.
-pub mod r0vm_crypto;
 /// Implementation for caching support in derivation.
 pub mod driver;
 /// Implementation for an execution engine with caching support.
@@ -38,6 +36,8 @@ pub mod kona;
 pub mod oracle;
 /// Structures and logic for defining preconditions for Kailua proofs.
 pub mod precondition;
+/// R0VM-accelerated revm `Crypto` provider for EVM precompiles.
+pub mod r0vm_crypto;
 /// Utility methods for zero-copy (de)serialization using the `rkyv` crate.
 pub mod rkyv;
 /// A module for representing oracle-backed stateless client witness data.

--- a/crates/kona/src/r0vm_crypto.rs
+++ b/crates/kona/src/r0vm_crypto.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! revm `Crypto` adapter over the primitives in `zeth-r0vm-precompile`.
+//! revm `Crypto` adapter over the primitives in `risc0-crypto-evm`.
 //!
 //! The adapter routes `sha256`, `modexp`, `bn254_g1_{add,mul}`,
 //! `secp256r1_verify_signature`, and `secp256k1_ecrecover` through
-//! [`zeth_r0vm_precompile`]. All other `Crypto` methods fall through to
+//! [`risc0_crypto_evm`]. All other `Crypto` methods fall through to
 //! `DefaultCrypto`.
 //!
 //! [`install_r0vm_crypto`] is only defined on the zkVM target — calling it
@@ -42,7 +42,7 @@ struct R0vmCrypto;
 impl alloy_evm::revm::precompile::Crypto for R0vmCrypto {
     #[inline]
     fn sha256(&self, input: &[u8]) -> [u8; 32] {
-        zeth_r0vm_precompile::sha256(input)
+        risc0_crypto_evm::sha256(input)
     }
 
     #[inline]
@@ -53,7 +53,7 @@ impl alloy_evm::revm::precompile::Crypto for R0vmCrypto {
         modulus: &[u8],
     ) -> Result<Vec<u8>, alloy_evm::revm::precompile::PrecompileError> {
         use alloy_evm::revm::precompile::{Crypto, DefaultCrypto};
-        match zeth_r0vm_precompile::modexp(base, exp, modulus) {
+        match risc0_crypto_evm::modexp(base, exp, modulus) {
             Some(out) => Ok(out),
             None => DefaultCrypto.modexp(base, exp, modulus),
         }
@@ -65,7 +65,7 @@ impl alloy_evm::revm::precompile::Crypto for R0vmCrypto {
         p1: &[u8],
         p2: &[u8],
     ) -> Result<[u8; 64], alloy_evm::revm::precompile::PrecompileError> {
-        zeth_r0vm_precompile::bn254_g1_add(p1, p2)
+        risc0_crypto_evm::bn254_g1_add(p1, p2)
             .ok_or(alloy_evm::revm::precompile::PrecompileError::Bn254AffineGFailedToCreate)
     }
 
@@ -75,13 +75,13 @@ impl alloy_evm::revm::precompile::Crypto for R0vmCrypto {
         point: &[u8],
         scalar: &[u8],
     ) -> Result<[u8; 64], alloy_evm::revm::precompile::PrecompileError> {
-        zeth_r0vm_precompile::bn254_g1_mul(point, scalar)
+        risc0_crypto_evm::bn254_g1_mul(point, scalar)
             .ok_or(alloy_evm::revm::precompile::PrecompileError::Bn254AffineGFailedToCreate)
     }
 
     #[inline]
     fn secp256r1_verify_signature(&self, msg: &[u8; 32], sig: &[u8; 64], pk: &[u8; 64]) -> bool {
-        zeth_r0vm_precompile::secp256r1_verify(msg, sig, pk)
+        risc0_crypto_evm::secp256r1_verify(msg, sig, pk)
     }
 
     #[inline]
@@ -91,7 +91,7 @@ impl alloy_evm::revm::precompile::Crypto for R0vmCrypto {
         recid: u8,
         msg: &[u8; 32],
     ) -> Result<[u8; 32], alloy_evm::revm::precompile::PrecompileError> {
-        zeth_r0vm_precompile::secp256k1_ecrecover(sig, recid, msg)
+        risc0_crypto_evm::secp256k1_ecrecover(sig, recid, msg)
             .map(|addr| addr.into_word().0)
             .ok_or(alloy_evm::revm::precompile::PrecompileError::Secp256k1RecoverFailed)
     }

--- a/crates/kona/src/r0vm_crypto.rs
+++ b/crates/kona/src/r0vm_crypto.rs
@@ -19,6 +19,15 @@
 //! [`risc0_crypto_evm`]. All other `Crypto` methods fall through to
 //! `DefaultCrypto`.
 //!
+//! ## Experimental, opt-in
+//!
+//! Until `risc0-crypto` has been fully audited this provider is treated as
+//! experimental. Installation is gated at runtime by
+//! [`Witness::enable_experimental_r0vm_crypto`](crate::witness::Witness),
+//! defaulting to `false`. Soundness depends on this provider being
+//! functionally equivalent to revm's `DefaultCrypto` on every input — flipping
+//! the witness flag must not change the proof journal, only its proving cost.
+//!
 //! [`install_r0vm_crypto`] is only defined on the zkVM target — calling it
 //! from host code is a compile error, not a silent no-op. Callers gate the
 //! install point with the same `cfg` attribute. Revm types are pulled in via

--- a/crates/kona/src/witness.rs
+++ b/crates/kona/src/witness.rs
@@ -60,6 +60,13 @@ pub struct Witness<O: WitnessOracle> {
     /// Represents the fault-proof virtual machine program image id.
     #[rkyv(with = B256Def)]
     pub fpvm_image_id: B256,
+    /// Opt-in switch for the experimental R0VM-accelerated revm `Crypto` provider
+    /// backed by `risc0-crypto-evm`. When `false` (the default), the guest leaves
+    /// revm's `DefaultCrypto` in place. The two providers MUST be functionally
+    /// equivalent on every input revm hands them; this flag only changes proving
+    /// cost, not the journal. Will remain opt-in until `risc0-crypto` has been
+    /// fully audited.
+    pub enable_experimental_r0vm_crypto: bool,
 }
 
 impl Witness<VecOracle> {
@@ -112,6 +119,7 @@ pub mod tests {
             ],
             stitched_boot_info: gen_boot_infos(32, 128),
             fpvm_image_id: keccak256(b"fpvm_image_id"),
+            enable_experimental_r0vm_crypto: false,
         };
 
         (witness, values)

--- a/crates/prover/src/args.rs
+++ b/crates/prover/src/args.rs
@@ -77,6 +77,12 @@ pub struct ProvingArgs {
     /// Whether to export profiling data to a CSV file
     #[clap(long, env, default_value_t = false)]
     pub export_profile_csv: bool,
+    /// Opt in to the experimental R0VM-accelerated revm `Crypto` provider backed
+    /// by `risc0-crypto-evm`. Off by default until `risc0-crypto` has been fully
+    /// audited. The two providers are required to be functionally equivalent;
+    /// this flag only changes proving cost, not the journal.
+    #[clap(long, env, default_value_t = false)]
+    pub enable_experimental_r0vm_crypto: bool,
 
     #[clap(flatten)]
     #[cfg(feature = "eigen")]
@@ -108,6 +114,8 @@ impl ProvingArgs {
                     .then(|| String::from("--skip-derivation-proof")),
                 self.skip_await_proof
                     .then(|| String::from("--skip-await-proof")),
+                self.enable_experimental_r0vm_crypto
+                    .then(|| String::from("--enable-experimental-r0vm-crypto")),
             ]
             .into_iter()
             .flatten(),

--- a/crates/prover/src/client/proving.rs
+++ b/crates/prover/src/client/proving.rs
@@ -98,7 +98,7 @@ where
         .await
         .map_err(ProvingError::OtherError)?;
     // Run witgen client to get correct BootInfo and Precondition
-    let (boot_info, proof_journal, updated_precondition, traced_driver, witness, extra_frames) =
+    let (boot_info, proof_journal, updated_precondition, traced_driver, mut witness, extra_frames) =
         match (proving.use_hokulea(), proving.use_hana()) {
             #[cfg(feature = "eigen")]
             (true, _) => {
@@ -220,6 +220,9 @@ where
             }
         };
     drop(witgen_permit);
+
+    // Propagate the experimental-crypto opt-in into the witness so the guest sees it.
+    witness.enable_experimental_r0vm_crypto = proving.enable_experimental_r0vm_crypto;
 
     // Commit derivation trace to driver file
     let driver_boot = BootInfo::load(preimage_oracle.as_ref())

--- a/crates/prover/src/client/witgen.rs
+++ b/crates/prover/src/client/witgen.rs
@@ -133,6 +133,8 @@ where
         stitched_preconditions,
         stitched_boot_info,
         fpvm_image_id,
+        // Filled in by the host caller after witgen returns.
+        enable_experimental_r0vm_crypto: false,
     };
     witness
         .oracle_witness


### PR DESCRIPTION
Adds opt-in `--enable-experimental-r0vm-crypto` flag that routes guest EVM precompiles (sha256, modexp, bn254 G1 add/mul, secp256r1 verify, secp256k1 ecrecover) through [`risc0-crypto-evm`](https://github.com/boundless-xyz/risc0-crypto). Off by default until `risc0-crypto` is fully audited; other precompiles fall through to `DefaultCrypto`. The flag lives in the witness so it can be toggled without rebaking the guest image ID.

Per upstream bench: ~4.7× ecrecover, ~4.2× BN254 G1 add, ~19.3× BN254 G1 mul vs. the risc0-patched upstream crates.