### PR TITLE
fix: rename boundless_legacy_pricing -> boundless_dynamic_pricing

### DIFF
--- a/book/src/validator.md
+++ b/book/src/validator.md
@@ -189,11 +189,13 @@ for every fault proof, a proof request is submitted to the network, where it goe
 [proof life-cycle](https://docs.boundless.network/developers/proof-lifecycle) on Boundless, before being published by
 your validator to settle a dispute.
 
-Pricing, timing, and collateral for proof requests are handled automatically by the
-[Boundless SDK](https://docs.boundless.network/developers/tutorials/request). The SDK determines
-appropriate prices from market data and gas costs, sets cycle-aware timeouts, and uses chain-specific
-collateral defaults. See the [auction parameter guide](https://docs.boundless.network/developers/tutorials/auction)
-for details on how the reverse Dutch auction works.
+Pricing, timing, and collateral for proof requests can either be computed from static wei-based
+parameters (the default — see [Legacy Pricing](#legacy-pricing) below) or delegated to the
+[Boundless SDK](https://docs.boundless.network/developers/tutorials/request) by passing
+`--boundless-dynamic-pricing`. The SDK determines appropriate prices from market data and gas
+costs, sets cycle-aware timeouts, and uses chain-specific collateral defaults. See the
+[auction parameter guide](https://docs.boundless.network/developers/tutorials/auction) for
+details on how the reverse Dutch auction works.
 
 This functionality requires some additional parameters when starting the validator.
 These parameters can be passed in as CLI arguments or set as environment variables.
@@ -215,9 +217,10 @@ These parameters can be passed in as CLI arguments or set as environment variabl
 * `boundless-assume-cycles-per-byte`: Skip preflighting and assume a fixed cycle count per input byte.
 * `boundless-assume-cycles-per-snark`: Skip preflighting and assume a fixed cycle count per recursive snark.
 
-#### Pricing
-By default, the Boundless SDK sets pricing automatically based on market conditions and gas costs.
-The following optional parameters allow you to override the SDK defaults:
+#### Dynamic Pricing (SDK)
+Pass `--boundless-dynamic-pricing` to delegate pricing to the Boundless SDK based on market
+conditions and gas costs. The following optional parameters allow you to override the SDK defaults
+(they require `--boundless-dynamic-pricing` to be set):
 * `boundless-min-price-per-cycle`: Minimum price per cycle, e.g. `"0.00001 USD"` or `"0.0000001 ETH"`. Requires a unit. If unset, the SDK uses market pricing from the price provider.
 * `boundless-max-price-per-cycle`: Maximum price per cycle, same format. If unset, the SDK uses a market-calibrated default plus a gas cost buffer.
 * `boundless-max-price-cap`: Hard cap on total order price (e.g. `"0.5 ETH"`, `"100 USD"`). Safety mechanism to prevent excessive spending.
@@ -237,9 +240,8 @@ When a proof request expires without being fulfilled, it is automatically resubm
 * `boundless-order-funding-threshold`: Threshold (wei) for `below-threshold` funding mode.
 
 #### Legacy Pricing
-For backward compatibility, static wei-based pricing can be enabled with `--boundless-legacy-pricing`.
-When this flag is set, the SDK's dynamic pricing is bypassed and the following parameters are used instead.
-These flags are hidden from `--help` and require `--boundless-legacy-pricing` to be set.
+Legacy static wei-based pricing is the **default** path. The following parameters tune it. They are
+hidden from `--help` and are rejected when `--boundless-dynamic-pricing` is set.
 
 * `boundless-cycle-min-wei`: Starting price (wei) per cycle (Default `200000000`).
 * `boundless-cycle-max-wei`: Maximum price (wei) per cycle (Default `600000000`).

--- a/crates/prover/src/risczero/boundless.rs
+++ b/crates/prover/src/risczero/boundless.rs
@@ -127,7 +127,13 @@ pub struct MarketProviderConfig {
     pub boundless_order_stream_url: Option<Cow<'static, str>>,
 
     /// Whether to look back at prior proof requests
-    #[clap(long, env, required = false, default_value_t = true)]
+    #[clap(
+        long,
+        env,
+        required = false,
+        default_value_t = true,
+        action = clap::ArgAction::Set
+    )]
     pub boundless_look_back: bool,
     /// Whether to skip preflighting execution and assume a fixed cycle count.
     #[clap(long, env, required = false)]
@@ -168,7 +174,13 @@ pub struct MarketProviderConfig {
     #[clap(long, env, required = false, default_value_t = 12)]
     pub boundless_order_check_interval: u64,
     /// Whether to enable upload caching
-    #[clap(long, env, required = false, default_value_t = true)]
+    #[clap(
+        long,
+        env,
+        required = false,
+        default_value_t = true,
+        action = clap::ArgAction::Set
+    )]
     pub boundless_enable_upload_caching: bool,
 
     /// Funding mode for order submission.
@@ -382,9 +394,10 @@ impl MarketProviderConfig {
             ]);
         };
         // Lookback
-        if self.boundless_look_back {
-            proving_args.push(String::from("--boundless-look-back"));
-        }
+        proving_args.extend(vec![
+            String::from("--boundless-look-back"),
+            self.boundless_look_back.to_string(),
+        ]);
         // Preflight skip
         if let Some(cycle_count) = self.boundless_assume_cycle_count {
             proving_args.extend(vec![
@@ -1533,22 +1546,22 @@ impl R2Storage {
 mod tests {
     use super::*;
 
+    const BASE_ARGS: [&str; 5] = [
+        "kailua",
+        "--boundless-rpc-url",
+        "http://localhost:8545",
+        "--boundless-wallet-key",
+        "0101010101010101010101010101010101010101010101010101010101010101",
+    ];
+
     /// `boundless_dynamic_pricing` must be off by default, settable by bare flag, and
     /// included in `to_arg_vec` output when set.
     #[test]
     fn dynamic_pricing_flag_parses_and_propagates() {
-        let base = [
-            "kailua",
-            "--boundless-rpc-url",
-            "http://localhost:8545",
-            "--boundless-wallet-key",
-            "0101010101010101010101010101010101010101010101010101010101010101",
-        ];
-
-        let default_cfg = MarketProviderConfig::try_parse_from(base).unwrap();
+        let default_cfg = MarketProviderConfig::try_parse_from(BASE_ARGS).unwrap();
         assert!(!default_cfg.boundless_dynamic_pricing);
 
-        let mut enabled = base.to_vec();
+        let mut enabled = BASE_ARGS.to_vec();
         enabled.push("--boundless-dynamic-pricing");
         let parent = MarketProviderConfig::try_parse_from(enabled).unwrap();
         assert!(parent.boundless_dynamic_pricing);
@@ -1557,5 +1570,27 @@ mod tests {
         assert!(serialized
             .iter()
             .any(|s| s == "--boundless-dynamic-pricing"));
+    }
+
+    /// The default-true bool flags must accept `--flag=false` on the CLI and round-trip
+    /// a `false` override through `to_arg_vec` without the child re-parse silently
+    /// snapping back to the default.
+    #[test]
+    fn default_true_bool_flags_can_be_disabled_and_round_trip() {
+        let mut overridden = BASE_ARGS.to_vec();
+        overridden.extend([
+            "--boundless-look-back=false",
+            "--boundless-enable-upload-caching=false",
+        ]);
+        let parent = MarketProviderConfig::try_parse_from(overridden).unwrap();
+        assert!(!parent.boundless_look_back);
+        assert!(!parent.boundless_enable_upload_caching);
+
+        let child_args: Vec<String> = std::iter::once("kailua".to_string())
+            .chain(parent.to_arg_vec(&None))
+            .collect();
+        let child = MarketProviderConfig::try_parse_from(&child_args).unwrap();
+        assert!(!child.boundless_look_back);
+        assert!(!child.boundless_enable_upload_caching);
     }
 }

--- a/crates/prover/src/risczero/boundless.rs
+++ b/crates/prover/src/risczero/boundless.rs
@@ -144,21 +144,11 @@ pub struct MarketProviderConfig {
 
     /// Minimum price per cycle (e.g., "0.00001 USD", "0.0000001 ETH").
     /// If unset, the SDK uses market pricing from the price provider.
-    #[clap(
-        long,
-        env,
-        required = false,
-        requires = "boundless_dynamic_pricing"
-    )]
+    #[clap(long, env, required = false, requires = "boundless_dynamic_pricing")]
     pub boundless_min_price_per_cycle: Option<Amount>,
     /// Maximum price per cycle (e.g., "0.00001 USD", "0.0000001 ETH").
     /// If unset, the SDK default (~100 Kwei/cycle, 99th percentile) is used.
-    #[clap(
-        long,
-        env,
-        required = false,
-        requires = "boundless_dynamic_pricing"
-    )]
+    #[clap(long, env, required = false, requires = "boundless_dynamic_pricing")]
     pub boundless_max_price_per_cycle: Option<Amount>,
     /// Hard cap on total order price (e.g., "0.5 ETH", "100 USD"). Safety mechanism.
     #[clap(long, env, required = false)]
@@ -1265,7 +1255,11 @@ pub async fn request_proof<A: NoUninit + Into<Digest>>(
 
     info!(
         "Boundless pricing path: {}",
-        if market.boundless_dynamic_pricing { "dynamic-sdk" } else { "legacy" }
+        if market.boundless_dynamic_pricing {
+            "dynamic-sdk"
+        } else {
+            "legacy"
+        }
     );
     let mut request = if !market.boundless_dynamic_pricing {
         // Legacy path: manual pricing with static wei parameters

--- a/crates/prover/src/risczero/boundless.rs
+++ b/crates/prover/src/risczero/boundless.rs
@@ -1528,3 +1528,63 @@ impl R2Storage {
         self.upload(&key, input.to_vec()).await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test for the `boundless_legacy_pricing` declaration that this PR replaced.
+    ///
+    /// The old `#[clap(long, env, default_value_t = true)] bool` had two bugs that combined
+    /// to make the SDK path effectively unreachable:
+    ///   1. clap derive picked `ArgAction::SetTrue`, so `--boundless-legacy-pricing=false`
+    ///      errored and bare `--boundless-legacy-pricing` kept it `true`. Only the env var
+    ///      spelled exactly `BOUNDLESS_LEGACY_PRICING=false` worked.
+    ///   2. `to_arg_vec` emitted the flag only when `true`, so even a successful parent
+    ///      override didn't reach the prover subprocess — the child fell back to the
+    ///      `true` default.
+    ///
+    /// Both bugs disappear when the field is named `boundless_dynamic_pricing` with
+    /// `default_value_t = false` (opt-in). This test pins that:
+    ///   - bare `--boundless-dynamic-pricing` parses to `true` (would fail if anyone
+    ///     re-introduces `default_value_t = true` here);
+    ///   - `to_arg_vec` includes `--boundless-dynamic-pricing` when the value is `true`
+    ///     (would fail if the emit-when-true convention is broken).
+    #[test]
+    fn dynamic_pricing_flag_parses_and_propagates() {
+        let base = [
+            "kailua",
+            "--boundless-rpc-url",
+            "http://localhost:8545",
+            "--boundless-wallet-key",
+            "0101010101010101010101010101010101010101010101010101010101010101",
+        ];
+
+        // No flag → legacy is the default. Catches a regression that flips the default
+        // back to `true` (which combined with `default_value_t = true` on a bool would
+        // re-introduce the clap quirk where `--…=false` errors).
+        let default_cfg = MarketProviderConfig::try_parse_from(base).unwrap();
+        assert!(
+            !default_cfg.boundless_dynamic_pricing,
+            "legacy pricing must be the default"
+        );
+
+        // Bare `--boundless-dynamic-pricing` → enabled. Would fail under the old
+        // `default_value_t = true` shape because the SetTrue action couldn't distinguish
+        // it from the default.
+        let mut enabled = base.to_vec();
+        enabled.push("--boundless-dynamic-pricing");
+        let parent = MarketProviderConfig::try_parse_from(enabled).unwrap();
+        assert!(parent.boundless_dynamic_pricing);
+
+        // `to_arg_vec` must propagate the flag (the validator spawns the prover as a
+        // subprocess and serializes its config through this method).
+        let serialized = parent.to_arg_vec(&None);
+        assert!(
+            serialized
+                .iter()
+                .any(|s| s == "--boundless-dynamic-pricing"),
+            "to_arg_vec dropped --boundless-dynamic-pricing; got {serialized:?}"
+        );
+    }
+}

--- a/crates/prover/src/risczero/boundless.rs
+++ b/crates/prover/src/risczero/boundless.rs
@@ -1534,7 +1534,7 @@ mod tests {
     use super::*;
 
     /// `boundless_dynamic_pricing` must be off by default, settable by bare flag, and
-    /// propagated by `to_arg_vec` (validator → prover subprocess).
+    /// included in `to_arg_vec` output when set.
     #[test]
     fn dynamic_pricing_flag_parses_and_propagates() {
         let base = [

--- a/crates/prover/src/risczero/boundless.rs
+++ b/crates/prover/src/risczero/boundless.rs
@@ -148,7 +148,7 @@ pub struct MarketProviderConfig {
         long,
         env,
         required = false,
-        conflicts_with = "boundless_legacy_pricing"
+        requires = "boundless_dynamic_pricing"
     )]
     pub boundless_min_price_per_cycle: Option<Amount>,
     /// Maximum price per cycle (e.g., "0.00001 USD", "0.0000001 ETH").
@@ -157,7 +157,7 @@ pub struct MarketProviderConfig {
         long,
         env,
         required = false,
-        conflicts_with = "boundless_legacy_pricing"
+        requires = "boundless_dynamic_pricing"
     )]
     pub boundless_max_price_per_cycle: Option<Amount>,
     /// Hard cap on total order price (e.g., "0.5 ETH", "100 USD"). Safety mechanism.
@@ -191,10 +191,10 @@ pub struct MarketProviderConfig {
     #[clap(long, env, required = false)]
     pub boundless_order_funding_threshold: Option<U256>,
 
-    /// Use legacy static wei-based pricing instead of dynamic SDK pricing.
-    /// When enabled, the flags below are used instead of the SDK's OfferLayer.
-    #[clap(long, env, required = false, default_value_t = true)]
-    pub boundless_legacy_pricing: bool,
+    /// Opt in to the Boundless SDK's dynamic pricing (`OfferLayer`).
+    /// When unset (the default), the legacy static wei-based pricing parameters below are used.
+    #[clap(long, env, required = false, default_value_t = false)]
+    pub boundless_dynamic_pricing: bool,
     /// Starting price (wei) per cycle.
     #[clap(
         long,
@@ -202,7 +202,7 @@ pub struct MarketProviderConfig {
         required = false,
         default_value = "200000000",
         hide = true,
-        requires = "boundless_legacy_pricing"
+        conflicts_with = "boundless_dynamic_pricing"
     )]
     pub boundless_cycle_min_wei: U256,
     /// Maximum price (wei) per cycle.
@@ -212,7 +212,7 @@ pub struct MarketProviderConfig {
         required = false,
         default_value = "600000000",
         hide = true,
-        requires = "boundless_legacy_pricing"
+        conflicts_with = "boundless_dynamic_pricing"
     )]
     pub boundless_cycle_max_wei: U256,
     /// Minimum megacycles per proving order.
@@ -222,7 +222,7 @@ pub struct MarketProviderConfig {
         required = false,
         default_value_t = 250,
         hide = true,
-        requires = "boundless_legacy_pricing"
+        conflicts_with = "boundless_dynamic_pricing"
     )]
     pub boundless_mega_cycle_min: u64,
     /// Collateral (ZKC) per megacycle.
@@ -232,7 +232,7 @@ pub struct MarketProviderConfig {
         required = false,
         default_value = "2500000000000000",
         hide = true,
-        requires = "boundless_legacy_pricing"
+        conflicts_with = "boundless_dynamic_pricing"
     )]
     pub boundless_mega_cycle_collateral: U256,
     /// Minimum collateral (ZKC) per order.
@@ -242,7 +242,7 @@ pub struct MarketProviderConfig {
         required = false,
         default_value = "5000000000000000000",
         hide = true,
-        requires = "boundless_legacy_pricing"
+        conflicts_with = "boundless_dynamic_pricing"
     )]
     pub boundless_order_min_collateral: U256,
     /// Multiplier for delay before order price starts ramping up.
@@ -252,7 +252,7 @@ pub struct MarketProviderConfig {
         required = false,
         default_value_t = 0.5,
         hide = true,
-        requires = "boundless_legacy_pricing"
+        conflicts_with = "boundless_dynamic_pricing"
     )]
     pub boundless_order_bid_delay_factor: f64,
     /// Minimum number of seconds to set as bid delay time.
@@ -262,7 +262,7 @@ pub struct MarketProviderConfig {
         required = false,
         default_value_t = 120,
         hide = true,
-        requires = "boundless_legacy_pricing"
+        conflicts_with = "boundless_dynamic_pricing"
     )]
     pub boundless_order_min_bid_delay: u64,
     /// Multiplier for order price to ramp up from min to max.
@@ -272,7 +272,7 @@ pub struct MarketProviderConfig {
         required = false,
         default_value_t = 1.0,
         hide = true,
-        requires = "boundless_legacy_pricing"
+        conflicts_with = "boundless_dynamic_pricing"
     )]
     pub boundless_order_ramp_up_factor: f64,
     /// Minimum number of seconds to set as ramp up time.
@@ -282,7 +282,7 @@ pub struct MarketProviderConfig {
         required = false,
         default_value_t = 600,
         hide = true,
-        requires = "boundless_legacy_pricing"
+        conflicts_with = "boundless_dynamic_pricing"
     )]
     pub boundless_order_min_ramp_up: u32,
     /// Multiplier for order fulfillment timeout (seconds/segment) after locking.
@@ -292,7 +292,7 @@ pub struct MarketProviderConfig {
         required = false,
         default_value_t = 3.0,
         hide = true,
-        requires = "boundless_legacy_pricing"
+        conflicts_with = "boundless_dynamic_pricing"
     )]
     pub boundless_order_lock_timeout_factor: f64,
     /// Minimum number of seconds to set as lock timeout time.
@@ -302,7 +302,7 @@ pub struct MarketProviderConfig {
         required = false,
         default_value_t = 1200,
         hide = true,
-        requires = "boundless_legacy_pricing"
+        conflicts_with = "boundless_dynamic_pricing"
     )]
     pub boundless_order_min_lock_timeout: u32,
     /// Multiplier for order expiry timeout (seconds/segment) after lock timeout.
@@ -312,7 +312,7 @@ pub struct MarketProviderConfig {
         required = false,
         default_value_t = 1.0,
         hide = true,
-        requires = "boundless_legacy_pricing"
+        conflicts_with = "boundless_dynamic_pricing"
     )]
     pub boundless_order_expiry_factor: f64,
     /// Minimum number of seconds to set as expiry time.
@@ -322,7 +322,7 @@ pub struct MarketProviderConfig {
         required = false,
         default_value_t = 900,
         hide = true,
-        requires = "boundless_legacy_pricing"
+        conflicts_with = "boundless_dynamic_pricing"
     )]
     pub boundless_order_min_expiry: u32,
 }
@@ -421,9 +421,10 @@ impl MarketProviderConfig {
                 cap.to_string(),
             ]);
         }
-        if self.boundless_legacy_pricing {
+        if self.boundless_dynamic_pricing {
+            proving_args.push(String::from("--boundless-dynamic-pricing"));
+        } else {
             proving_args.extend(vec![
-                String::from("--boundless-legacy-pricing"),
                 String::from("--boundless-cycle-min-wei"),
                 self.boundless_cycle_min_wei.to_string(),
                 String::from("--boundless-cycle-max-wei"),
@@ -1262,7 +1263,11 @@ pub async fn request_proof<A: NoUninit + Into<Digest>>(
         )
         .with_request_id(RequestId::new(boundless_wallet_address, fresh_nonce));
 
-    let mut request = if market.boundless_legacy_pricing {
+    info!(
+        "Boundless pricing path: {}",
+        if market.boundless_dynamic_pricing { "dynamic-sdk" } else { "legacy" }
+    );
+    let mut request = if !market.boundless_dynamic_pricing {
         // Legacy path: manual pricing with static wei parameters
         let boundless_rpc_time = retry_res_timeout!(
             15,

--- a/crates/prover/src/risczero/boundless.rs
+++ b/crates/prover/src/risczero/boundless.rs
@@ -127,13 +127,7 @@ pub struct MarketProviderConfig {
     pub boundless_order_stream_url: Option<Cow<'static, str>>,
 
     /// Whether to look back at prior proof requests
-    #[clap(
-        long,
-        env,
-        required = false,
-        default_value_t = true,
-        action = clap::ArgAction::Set
-    )]
+    #[clap(long, env, required = false, default_value_t = true)]
     pub boundless_look_back: bool,
     /// Whether to skip preflighting execution and assume a fixed cycle count.
     #[clap(long, env, required = false)]
@@ -174,13 +168,7 @@ pub struct MarketProviderConfig {
     #[clap(long, env, required = false, default_value_t = 12)]
     pub boundless_order_check_interval: u64,
     /// Whether to enable upload caching
-    #[clap(
-        long,
-        env,
-        required = false,
-        default_value_t = true,
-        action = clap::ArgAction::Set
-    )]
+    #[clap(long, env, required = false, default_value_t = true)]
     pub boundless_enable_upload_caching: bool,
 
     /// Funding mode for order submission.
@@ -394,10 +382,9 @@ impl MarketProviderConfig {
             ]);
         };
         // Lookback
-        proving_args.extend(vec![
-            String::from("--boundless-look-back"),
-            self.boundless_look_back.to_string(),
-        ]);
+        if self.boundless_look_back {
+            proving_args.push(String::from("--boundless-look-back"));
+        }
         // Preflight skip
         if let Some(cycle_count) = self.boundless_assume_cycle_count {
             proving_args.extend(vec![
@@ -1546,22 +1533,22 @@ impl R2Storage {
 mod tests {
     use super::*;
 
-    const BASE_ARGS: [&str; 5] = [
-        "kailua",
-        "--boundless-rpc-url",
-        "http://localhost:8545",
-        "--boundless-wallet-key",
-        "0101010101010101010101010101010101010101010101010101010101010101",
-    ];
-
     /// `boundless_dynamic_pricing` must be off by default, settable by bare flag, and
     /// included in `to_arg_vec` output when set.
     #[test]
     fn dynamic_pricing_flag_parses_and_propagates() {
-        let default_cfg = MarketProviderConfig::try_parse_from(BASE_ARGS).unwrap();
+        let base = [
+            "kailua",
+            "--boundless-rpc-url",
+            "http://localhost:8545",
+            "--boundless-wallet-key",
+            "0101010101010101010101010101010101010101010101010101010101010101",
+        ];
+
+        let default_cfg = MarketProviderConfig::try_parse_from(base).unwrap();
         assert!(!default_cfg.boundless_dynamic_pricing);
 
-        let mut enabled = BASE_ARGS.to_vec();
+        let mut enabled = base.to_vec();
         enabled.push("--boundless-dynamic-pricing");
         let parent = MarketProviderConfig::try_parse_from(enabled).unwrap();
         assert!(parent.boundless_dynamic_pricing);
@@ -1570,27 +1557,5 @@ mod tests {
         assert!(serialized
             .iter()
             .any(|s| s == "--boundless-dynamic-pricing"));
-    }
-
-    /// The default-true bool flags must accept `--flag=false` on the CLI and round-trip
-    /// a `false` override through `to_arg_vec` without the child re-parse silently
-    /// snapping back to the default.
-    #[test]
-    fn default_true_bool_flags_can_be_disabled_and_round_trip() {
-        let mut overridden = BASE_ARGS.to_vec();
-        overridden.extend([
-            "--boundless-look-back=false",
-            "--boundless-enable-upload-caching=false",
-        ]);
-        let parent = MarketProviderConfig::try_parse_from(overridden).unwrap();
-        assert!(!parent.boundless_look_back);
-        assert!(!parent.boundless_enable_upload_caching);
-
-        let child_args: Vec<String> = std::iter::once("kailua".to_string())
-            .chain(parent.to_arg_vec(&None))
-            .collect();
-        let child = MarketProviderConfig::try_parse_from(&child_args).unwrap();
-        assert!(!child.boundless_look_back);
-        assert!(!child.boundless_enable_upload_caching);
     }
 }

--- a/crates/prover/src/risczero/boundless.rs
+++ b/crates/prover/src/risczero/boundless.rs
@@ -1533,23 +1533,8 @@ impl R2Storage {
 mod tests {
     use super::*;
 
-    /// Regression test for the `boundless_legacy_pricing` declaration that this PR replaced.
-    ///
-    /// The old `#[clap(long, env, default_value_t = true)] bool` had two bugs that combined
-    /// to make the SDK path effectively unreachable:
-    ///   1. clap derive picked `ArgAction::SetTrue`, so `--boundless-legacy-pricing=false`
-    ///      errored and bare `--boundless-legacy-pricing` kept it `true`. Only the env var
-    ///      spelled exactly `BOUNDLESS_LEGACY_PRICING=false` worked.
-    ///   2. `to_arg_vec` emitted the flag only when `true`, so even a successful parent
-    ///      override didn't reach the prover subprocess — the child fell back to the
-    ///      `true` default.
-    ///
-    /// Both bugs disappear when the field is named `boundless_dynamic_pricing` with
-    /// `default_value_t = false` (opt-in). This test pins that:
-    ///   - bare `--boundless-dynamic-pricing` parses to `true` (would fail if anyone
-    ///     re-introduces `default_value_t = true` here);
-    ///   - `to_arg_vec` includes `--boundless-dynamic-pricing` when the value is `true`
-    ///     (would fail if the emit-when-true convention is broken).
+    /// `boundless_dynamic_pricing` must be off by default, settable by bare flag, and
+    /// propagated by `to_arg_vec` (validator → prover subprocess).
     #[test]
     fn dynamic_pricing_flag_parses_and_propagates() {
         let base = [
@@ -1560,31 +1545,17 @@ mod tests {
             "0101010101010101010101010101010101010101010101010101010101010101",
         ];
 
-        // No flag → legacy is the default. Catches a regression that flips the default
-        // back to `true` (which combined with `default_value_t = true` on a bool would
-        // re-introduce the clap quirk where `--…=false` errors).
         let default_cfg = MarketProviderConfig::try_parse_from(base).unwrap();
-        assert!(
-            !default_cfg.boundless_dynamic_pricing,
-            "legacy pricing must be the default"
-        );
+        assert!(!default_cfg.boundless_dynamic_pricing);
 
-        // Bare `--boundless-dynamic-pricing` → enabled. Would fail under the old
-        // `default_value_t = true` shape because the SetTrue action couldn't distinguish
-        // it from the default.
         let mut enabled = base.to_vec();
         enabled.push("--boundless-dynamic-pricing");
         let parent = MarketProviderConfig::try_parse_from(enabled).unwrap();
         assert!(parent.boundless_dynamic_pricing);
 
-        // `to_arg_vec` must propagate the flag (the validator spawns the prover as a
-        // subprocess and serializes its config through this method).
         let serialized = parent.to_arg_vec(&None);
-        assert!(
-            serialized
-                .iter()
-                .any(|s| s == "--boundless-dynamic-pricing"),
-            "to_arg_vec dropped --boundless-dynamic-pricing; got {serialized:?}"
-        );
+        assert!(serialized
+            .iter()
+            .any(|s| s == "--boundless-dynamic-pricing"));
     }
 }


### PR DESCRIPTION
Renames `--boundless-legacy-pricing` (default `true`) to `--boundless-dynamic-pricing` (default `false`). Same behavior by default; opt-in now flips the right way.

**Previous bug:** disabling legacy was effectively impossible.

- `--boundless-legacy-pricing=false` → clap error (`SetTrue` action, can't take a value).
- bare `--boundless-legacy-pricing` → stays `true`.
- Validator→prover subprocess: `to_arg_vec` emitted the flag only when `true`, so even a successful env-var override on the parent didn't reach the child, which defaulted back to `true`.

With `default_value_t = false`, clap uses the canonical action, and emit-when-true matches the child default, so both paths work.

Also logs the active pricing path at request time.