### PR TITLE
fix: allow --flag=false on boundless_look_back and boundless_enable_upload_caching

### DIFF
--- a/crates/prover/src/risczero/boundless.rs
+++ b/crates/prover/src/risczero/boundless.rs
@@ -1547,7 +1547,7 @@ impl R2Storage {
 mod tests {
     use super::*;
 
-    const BASE_ARGS: [&str; 5] = [
+    const BASE_ARGS: &[&str] = &[
         "kailua",
         "--boundless-rpc-url",
         "http://localhost:8545",
@@ -1556,39 +1556,31 @@ mod tests {
     ];
 
     fn parse_with(extra: &[&str]) -> MarketProviderConfig {
-        let args: Vec<&str> = BASE_ARGS
-            .iter()
-            .copied()
-            .chain(extra.iter().copied())
-            .collect();
-        MarketProviderConfig::try_parse_from(args).unwrap()
+        MarketProviderConfig::try_parse_from(BASE_ARGS.iter().chain(extra.iter())).unwrap()
     }
 
-    /// `boundless_look_back` must accept `--flag=false` and emit the value via `to_arg_vec`.
+    fn value_after(args: &[String], flag: &str) -> String {
+        let idx = args.iter().position(|s| s == flag).unwrap();
+        args[idx + 1].clone()
+    }
+
     #[test]
     fn boundless_look_back_can_be_disabled_and_propagated() {
         let parent = parse_with(&["--boundless-look-back=false"]);
         assert!(!parent.boundless_look_back);
-
-        let serialized = parent.to_arg_vec(&None);
-        let idx = serialized
-            .iter()
-            .position(|s| s == "--boundless-look-back")
-            .unwrap();
-        assert_eq!(serialized[idx + 1], "false");
+        assert_eq!(
+            value_after(&parent.to_arg_vec(&None), "--boundless-look-back"),
+            "false"
+        );
     }
 
-    /// `boundless_enable_upload_caching` must accept `--flag=false` and emit the value via `to_arg_vec`.
     #[test]
     fn boundless_enable_upload_caching_can_be_disabled_and_propagated() {
         let parent = parse_with(&["--boundless-enable-upload-caching=false"]);
         assert!(!parent.boundless_enable_upload_caching);
-
-        let serialized = parent.to_arg_vec(&None);
-        let idx = serialized
-            .iter()
-            .position(|s| s == "--boundless-enable-upload-caching")
-            .unwrap();
-        assert_eq!(serialized[idx + 1], "false");
+        assert_eq!(
+            value_after(&parent.to_arg_vec(&None), "--boundless-enable-upload-caching"),
+            "false"
+        );
     }
 }

--- a/crates/prover/src/risczero/boundless.rs
+++ b/crates/prover/src/risczero/boundless.rs
@@ -1568,21 +1568,17 @@ mod tests {
     fn boundless_look_back_can_be_disabled_and_propagated() {
         let parent = parse_with(&["--boundless-look-back=false"]);
         assert!(!parent.boundless_look_back);
-        assert_eq!(
-            value_after(&parent.to_arg_vec(&None), "--boundless-look-back"),
-            "false"
-        );
+        let args = parent.to_arg_vec(&None);
+        assert_eq!(value_after(&args, "--boundless-look-back"), "false");
     }
 
     #[test]
     fn boundless_enable_upload_caching_can_be_disabled_and_propagated() {
         let parent = parse_with(&["--boundless-enable-upload-caching=false"]);
         assert!(!parent.boundless_enable_upload_caching);
+        let args = parent.to_arg_vec(&None);
         assert_eq!(
-            value_after(
-                &parent.to_arg_vec(&None),
-                "--boundless-enable-upload-caching"
-            ),
+            value_after(&args, "--boundless-enable-upload-caching"),
             "false"
         );
     }

--- a/crates/prover/src/risczero/boundless.rs
+++ b/crates/prover/src/risczero/boundless.rs
@@ -127,7 +127,13 @@ pub struct MarketProviderConfig {
     pub boundless_order_stream_url: Option<Cow<'static, str>>,
 
     /// Whether to look back at prior proof requests
-    #[clap(long, env, required = false, default_value_t = true)]
+    #[clap(
+        long,
+        env,
+        required = false,
+        default_value_t = true,
+        action = clap::ArgAction::Set
+    )]
     pub boundless_look_back: bool,
     /// Whether to skip preflighting execution and assume a fixed cycle count.
     #[clap(long, env, required = false)]
@@ -178,7 +184,13 @@ pub struct MarketProviderConfig {
     #[clap(long, env, required = false, default_value_t = 12)]
     pub boundless_order_check_interval: u64,
     /// Whether to enable upload caching
-    #[clap(long, env, required = false, default_value_t = true)]
+    #[clap(
+        long,
+        env,
+        required = false,
+        default_value_t = true,
+        action = clap::ArgAction::Set
+    )]
     pub boundless_enable_upload_caching: bool,
 
     /// Funding mode for order submission.
@@ -392,9 +404,10 @@ impl MarketProviderConfig {
             ]);
         };
         // Lookback
-        if self.boundless_look_back {
-            proving_args.push(String::from("--boundless-look-back"));
-        }
+        proving_args.extend(vec![
+            String::from("--boundless-look-back"),
+            self.boundless_look_back.to_string(),
+        ]);
         // Preflight skip
         if let Some(cycle_count) = self.boundless_assume_cycle_count {
             proving_args.extend(vec![
@@ -1527,5 +1540,55 @@ impl R2Storage {
         let digest = Sha256::digest(input);
         let key = format!("v2/kailua/input/{}.bin", hex::encode(digest));
         self.upload(&key, input.to_vec()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BASE_ARGS: [&str; 5] = [
+        "kailua",
+        "--boundless-rpc-url",
+        "http://localhost:8545",
+        "--boundless-wallet-key",
+        "0101010101010101010101010101010101010101010101010101010101010101",
+    ];
+
+    fn parse_with(extra: &[&str]) -> MarketProviderConfig {
+        let args: Vec<&str> = BASE_ARGS
+            .iter()
+            .copied()
+            .chain(extra.iter().copied())
+            .collect();
+        MarketProviderConfig::try_parse_from(args).unwrap()
+    }
+
+    /// `boundless_look_back` must accept `--flag=false` and emit the value via `to_arg_vec`.
+    #[test]
+    fn boundless_look_back_can_be_disabled_and_propagated() {
+        let parent = parse_with(&["--boundless-look-back=false"]);
+        assert!(!parent.boundless_look_back);
+
+        let serialized = parent.to_arg_vec(&None);
+        let idx = serialized
+            .iter()
+            .position(|s| s == "--boundless-look-back")
+            .unwrap();
+        assert_eq!(serialized[idx + 1], "false");
+    }
+
+    /// `boundless_enable_upload_caching` must accept `--flag=false` and emit the value via `to_arg_vec`.
+    #[test]
+    fn boundless_enable_upload_caching_can_be_disabled_and_propagated() {
+        let parent = parse_with(&["--boundless-enable-upload-caching=false"]);
+        assert!(!parent.boundless_enable_upload_caching);
+
+        let serialized = parent.to_arg_vec(&None);
+        let idx = serialized
+            .iter()
+            .position(|s| s == "--boundless-enable-upload-caching")
+            .unwrap();
+        assert_eq!(serialized[idx + 1], "false");
     }
 }

--- a/crates/prover/src/risczero/boundless.rs
+++ b/crates/prover/src/risczero/boundless.rs
@@ -1579,7 +1579,10 @@ mod tests {
         let parent = parse_with(&["--boundless-enable-upload-caching=false"]);
         assert!(!parent.boundless_enable_upload_caching);
         assert_eq!(
-            value_after(&parent.to_arg_vec(&None), "--boundless-enable-upload-caching"),
+            value_after(
+                &parent.to_arg_vec(&None),
+                "--boundless-enable-upload-caching"
+            ),
             "false"
         );
     }


### PR DESCRIPTION
Adds `action = clap::ArgAction::Set` to both flag declarations so clap takes a value instead of using the default `SetTrue` action. Switches `boundless_look_back`'s `to_arg_vec` to value form so `false` overrides survive serialization. `boundless_enable_upload_caching` already serialized in value form and was previously rejected by the child's `SetTrue` parser as `UnknownArgument: 'true'` — this also repairs that latent break.

**Breaking change:** bare `--boundless-look-back` and `--boundless-enable-upload-caching` now require a value. Both flags default to `true`, so the bare form was a no-op before this PR.

### Parsing semantics — `--boundless-look-back` (same shape applies to `--boundless-enable-upload-caching`)

| input                                | before          | after                      |
|--------------------------------------|-----------------|----------------------------|
| nothing                              | `true` (default) | `true` (default)          |
| `--boundless-look-back=false`        | error           | `false` ✓                  |
| `--boundless-look-back false`        | error           | `false` ✓                  |
| `--boundless-look-back=true`         | error           | `true` ✓                   |
| `BOUNDLESS_LOOK_BACK=false` (env)    | `false` ✓       | `false` ✓                  |
| `--boundless-look-back` (bare)       | `true` (no-op)  | error ← only regression    |

Two regression tests added (`boundless_look_back_can_be_disabled_and_propagated`, `boundless_enable_upload_caching_can_be_disabled_and_propagated`). Both panic at the clap parse step on `main` (`TooManyValues`) and pass on this branch.