### PR TITLE
feat(prover): add --boundless-dynamic-pricing-ramp-up-modifier

### DIFF
--- a/crates/prover/src/risczero/boundless.rs
+++ b/crates/prover/src/risczero/boundless.rs
@@ -335,6 +335,14 @@ pub struct MarketProviderConfig {
     /// proportionally (timeout stays greater than lockTimeout).
     #[clap(long, env, required = false, requires = "boundless_dynamic_pricing")]
     pub boundless_dynamic_pricing_timeout_modifier: Option<f64>,
+
+    /// Optional multiplier applied to the SDK-computed ramp-up period. Only valid together with
+    /// --boundless-dynamic-pricing (clap enforces this) and only applied on the dynamic pricing
+    /// path. Unset leaves the SDK-computed ramp-up unchanged; 2.0 doubles it. Set this consistently
+    /// with --boundless-dynamic-pricing-timeout-modifier so the ramp-up period stays within the
+    /// (scaled) lock timeout.
+    #[clap(long, env, required = false, requires = "boundless_dynamic_pricing")]
+    pub boundless_dynamic_pricing_ramp_up_modifier: Option<f64>,
 }
 
 impl MarketProviderConfig {
@@ -437,6 +445,12 @@ impl MarketProviderConfig {
             if let Some(modifier) = self.boundless_dynamic_pricing_timeout_modifier {
                 proving_args.extend(vec![
                     String::from("--boundless-dynamic-pricing-timeout-modifier"),
+                    modifier.to_string(),
+                ]);
+            }
+            if let Some(modifier) = self.boundless_dynamic_pricing_ramp_up_modifier {
+                proving_args.extend(vec![
+                    String::from("--boundless-dynamic-pricing-ramp-up-modifier"),
                     modifier.to_string(),
                 ]);
             }
@@ -1383,6 +1397,18 @@ pub async fn request_proof<A: NoUninit + Into<Digest>>(
             );
         }
 
+        // Optional ramp-up modifier (dynamic pricing only): scale the SDK-computed ramp-up period.
+        // Set this consistently with the timeout modifier so the ramp-up period stays within the
+        // (scaled) lock timeout. Applied before retry escalation so escalation compounds on top.
+        if let Some(modifier) = market.boundless_dynamic_pricing_ramp_up_modifier {
+            let prev_ramp_up = request.offer.rampUpPeriod;
+            request.offer.rampUpPeriod = (prev_ramp_up as f64 * modifier) as u32;
+            info!(
+                "Applied dynamic-pricing ramp-up modifier {}: rampUpPeriod {}s -> {}s",
+                modifier, prev_ramp_up, request.offer.rampUpPeriod,
+            );
+        }
+
         request
     };
 
@@ -1626,5 +1652,28 @@ mod tests {
         assert!(serialized
             .iter()
             .any(|s| s == "--boundless-dynamic-pricing"));
+    }
+
+    /// `boundless_dynamic_pricing_ramp_up_modifier` is optional (off by default), requires dynamic
+    /// pricing, and is propagated through `to_arg_vec` when set.
+    #[test]
+    fn dynamic_pricing_ramp_up_modifier_parses_and_propagates() {
+        let default_cfg = parse_with(&["--boundless-dynamic-pricing"]);
+        assert!(default_cfg
+            .boundless_dynamic_pricing_ramp_up_modifier
+            .is_none());
+
+        let parent = parse_with(&[
+            "--boundless-dynamic-pricing",
+            "--boundless-dynamic-pricing-ramp-up-modifier",
+            "2",
+        ]);
+        assert_eq!(parent.boundless_dynamic_pricing_ramp_up_modifier, Some(2.0));
+
+        let serialized = parent.to_arg_vec(&None);
+        assert_eq!(
+            value_after(&serialized, "--boundless-dynamic-pricing-ramp-up-modifier"),
+            "2",
+        );
     }
 }

--- a/crates/prover/src/risczero/boundless.rs
+++ b/crates/prover/src/risczero/boundless.rs
@@ -336,11 +336,7 @@ pub struct MarketProviderConfig {
     #[clap(long, env, required = false, requires = "boundless_dynamic_pricing")]
     pub boundless_dynamic_pricing_timeout_modifier: Option<f64>,
 
-    /// Optional multiplier applied to the SDK-computed ramp-up period. Only valid together with
-    /// --boundless-dynamic-pricing (clap enforces this) and only applied on the dynamic pricing
-    /// path. Unset leaves the SDK-computed ramp-up unchanged; 2.0 doubles it. Set this consistently
-    /// with --boundless-dynamic-pricing-timeout-modifier so the ramp-up period stays within the
-    /// (scaled) lock timeout.
+    /// Optional multiplier applied to the SDK-computed ramp-up period (dynamic pricing only).
     #[clap(long, env, required = false, requires = "boundless_dynamic_pricing")]
     pub boundless_dynamic_pricing_ramp_up_modifier: Option<f64>,
 }
@@ -1397,9 +1393,6 @@ pub async fn request_proof<A: NoUninit + Into<Digest>>(
             );
         }
 
-        // Optional ramp-up modifier (dynamic pricing only): scale the SDK-computed ramp-up period.
-        // Set this consistently with the timeout modifier so the ramp-up period stays within the
-        // (scaled) lock timeout. Applied before retry escalation so escalation compounds on top.
         if let Some(modifier) = market.boundless_dynamic_pricing_ramp_up_modifier {
             let prev_ramp_up = request.offer.rampUpPeriod;
             request.offer.rampUpPeriod = (prev_ramp_up as f64 * modifier) as u32;
@@ -1654,8 +1647,6 @@ mod tests {
             .any(|s| s == "--boundless-dynamic-pricing"));
     }
 
-    /// `boundless_dynamic_pricing_ramp_up_modifier` is optional (off by default), requires dynamic
-    /// pricing, and is propagated through `to_arg_vec` when set.
     #[test]
     fn dynamic_pricing_ramp_up_modifier_parses_and_propagates() {
         let default_cfg = parse_with(&["--boundless-dynamic-pricing"]);


### PR DESCRIPTION
## What

Adds an optional `--boundless-dynamic-pricing-ramp-up-modifier` (`BOUNDLESS_DYNAMIC_PRICING_RAMP_UP_MODIFIER`), a sibling to the existing `--boundless-dynamic-pricing-timeout-modifier` (#145).