### PR TITLE
Fix validator documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can test out Kailua's validity proving on a running chain through the follow
     * Compiles a release build of Kailua
 2. `just demo [BLOCKS_PER_PROOF] [L1_RPC] [BEACON_RPC] [L2_RPC] [OP_NODE_RPC]:`
     * Runs the release build against the target chain endpoints.
-    * See [here](validator.md#delegated-proof-generation) for advanced proving configuration
+    * See [here](book/src/validator.md#delegated-proof-generation) for advanced proving configuration
 
 ## Local Devnet
 


### PR DESCRIPTION
This PR fixes a broken documentation link in the root README.

The Proving Demo section linked to `validator.md#delegated-proof-generation`, but `validator.md` does not exist at the repository root. The validator documentation lives under `book/src/validator.md`, so this updates the link to point to the correct file and section.
