### PR TITLE
add --blocked-rpc-methods to answer blocklisted RPCs locally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,7 @@ dependencies = [
  "alloy-core",
  "alloy-eips 2.0.5",
  "alloy-genesis 2.0.5",
+ "alloy-json-rpc 2.0.5",
  "alloy-network 2.0.5",
  "alloy-provider 2.0.5",
  "alloy-pubsub",
@@ -7367,6 +7368,7 @@ dependencies = [
  "thousands",
  "tokio",
  "tokio-retry",
+ "tower 0.5.3",
  "tracing",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ thousands = "0.2.0"
 tokio = { version = "1.49.0", features = ["full"] }
 tokio-rayon = "2.1.0"
 tokio-retry = "0.3.0"
+tower = "0.5.3"
 url = { version = "2.5.4", features = ["serde"]}
 
 # Telemetry

--- a/bin/cli/tests/devnet.rs
+++ b/bin/cli/tests/devnet.rs
@@ -625,6 +625,9 @@ fn base_proving_args(max_witness_size: usize) -> ProvingArgs {
         skip_derivation_proof: false,
         skip_await_proof: false,
         clear_cache_data: true,
+        // Mirror the production config: block debug_executePayload so the payload witness
+        // hint falls through to fine-grained hints locally, without calling the node.
+        blocked_rpc_methods: vec!["debug_executePayload".to_string()],
         #[cfg(feature = "eigen")]
         hokulea: Default::default(),
         #[cfg(feature = "celestia")]

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -38,11 +38,12 @@ thousands.workspace = true
 tracing.workspace = true
 tokio.workspace = true
 tokio-retry.workspace = true
+tower.workspace = true
 reqwest.workspace = true
 url.workspace = true
 
 # Alloy
-alloy = { workspace = true, features = ["full", "kzg", "contract", "rlp", "sol-types"] }
+alloy = { workspace = true, features = ["full", "kzg", "contract", "rlp", "sol-types", "json-rpc"] }
 alloy-evm.workspace = true
 alloy-op-evm.workspace = true
 alloy-primitives.workspace = true

--- a/crates/prover/src/args.rs
+++ b/crates/prover/src/args.rs
@@ -23,8 +23,6 @@ use kailua_sync::args::{parse_address, parse_b256};
 use kailua_sync::provider::ProviderTimeoutArgs;
 use kailua_sync::telemetry::TelemetryArgs;
 use kona_host::single::{SingleChainHostError, SingleChainProviders};
-use kona_providers_alloy::{OnlineBeaconClient, OnlineBlobProvider};
-use op_alloy_network::Optimism;
 use std::cmp::Ordering;
 use std::panic::AssertUnwindSafe;
 use tracing::error;
@@ -253,45 +251,27 @@ impl ProveArgs {
     }
 
     pub async fn create_providers(&self) -> Result<SingleChainProviders, SingleChainHostError> {
-        if !self.proving.blocked_rpc_methods.is_empty() {
-            // Build the providers with the blocked-methods layer on the RPC clients. Mirrors
-            // kona's SingleChainHost::create_providers, which offers no layering hook.
-            let l1_provider = RootProvider::new(
-                self.rpc_client(
-                    self.kona
-                        .l1_node_address
-                        .as_ref()
-                        .ok_or(SingleChainHostError::Other("Provider must be set"))?,
-                )?,
-            );
-            let blob_provider = OnlineBlobProvider::init(OnlineBeaconClient::new_http(
-                self.kona
-                    .l1_beacon_address
-                    .clone()
-                    .ok_or(SingleChainHostError::Other("Beacon API URL must be set"))?,
-            ))
-            .await;
-            let l2_provider = RootProvider::<Optimism>::new(
-                self.rpc_client(
-                    self.kona
-                        .l2_node_address
-                        .as_ref()
-                        .ok_or(SingleChainHostError::Other("L2 node address must be set"))?,
-                )?,
-            );
-            return Ok(SingleChainProviders {
-                l1: l1_provider,
-                blobs: blob_provider,
-                l2: l2_provider,
-            });
-        }
-        AssertUnwindSafe(self.kona.clone().create_providers())
+        let mut providers = AssertUnwindSafe(self.kona.clone().create_providers())
             .catch_unwind()
             .await
             .unwrap_or_else(|err| {
                 error!("kona::create_providers panicked: {err:?}");
                 Err(SingleChainHostError::Other("create_providers panicked"))
-            })
+            })?;
+        // Re-wrap the L2 provider so `--blocked-rpc-methods` applies to it. The blockable
+        // methods (debug_executePayload, debug_executionWitness) are all served by the L2
+        // provider, so leaving the L1 and beacon providers as kona built them is sufficient.
+        // kona exposes no hook to layer the client during construction, so its L2 provider is
+        // discarded here; that is cheap because an HTTP `RootProvider` connects lazily.
+        if !self.proving.blocked_rpc_methods.is_empty() {
+            let l2_address = self
+                .kona
+                .l2_node_address
+                .as_ref()
+                .ok_or(SingleChainHostError::Other("L2 node address must be set"))?;
+            providers.l2 = RootProvider::new(self.rpc_client(l2_address)?);
+        }
+        Ok(providers)
     }
 
     pub fn to_arg_vec(&self) -> Vec<String> {

--- a/crates/prover/src/args.rs
+++ b/crates/prover/src/args.rs
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 use crate::risczero::boundless::BoundlessArgs;
+use crate::rpc::BlockedMethodsLayer;
+use alloy::providers::RootProvider;
+use alloy::rpc::client::{ClientBuilder, RpcClient};
 use alloy_primitives::{Address, B256};
 use clap::Parser;
 use futures::FutureExt;
@@ -20,6 +23,8 @@ use kailua_sync::args::{parse_address, parse_b256};
 use kailua_sync::provider::ProviderTimeoutArgs;
 use kailua_sync::telemetry::TelemetryArgs;
 use kona_host::single::{SingleChainHostError, SingleChainProviders};
+use kona_providers_alloy::{OnlineBeaconClient, OnlineBlobProvider};
+use op_alloy_network::Optimism;
 use std::cmp::Ordering;
 use std::panic::AssertUnwindSafe;
 use tracing::error;
@@ -80,6 +85,11 @@ pub struct ProvingArgs {
     /// Whether to export profiling data to a CSV file
     #[clap(long, env, default_value_t = false)]
     pub export_profile_csv: bool,
+    /// RPC methods that must not be sent to any provider; requests for them are answered
+    /// locally with a JSON-RPC "method not found" error (-32601) so callers take their
+    /// unsupported-method fallback path instead
+    #[clap(long, env, value_delimiter = ',')]
+    pub blocked_rpc_methods: Vec<String>,
 
     #[clap(flatten)]
     #[cfg(feature = "eigen")]
@@ -102,6 +112,12 @@ impl ProvingArgs {
             String::from("--num-concurrent-proofs"),
             self.num_concurrent_proofs.to_string(),
         ];
+        if !self.blocked_rpc_methods.is_empty() {
+            proving_args.extend(vec![
+                String::from("--blocked-rpc-methods"),
+                self.blocked_rpc_methods.join(","),
+            ]);
+        }
         // Core flags
         proving_args.extend(
             [
@@ -216,7 +232,59 @@ pub struct ProveArgs {
 }
 
 impl ProveArgs {
+    /// Builds an RPC client for the given URL, applying the blocked-methods layer when
+    /// `--blocked-rpc-methods` is configured. HTTP(S) URLs only: unlike
+    /// `RootProvider::connect`, this does not support ws:// or ipc endpoints, so those
+    /// remain usable only with an empty blocklist.
+    pub fn rpc_client(&self, url: &str) -> Result<RpcClient, SingleChainHostError> {
+        let url: reqwest::Url = url
+            .parse()
+            .map_err(|_| SingleChainHostError::Other("Invalid RPC URL"))?;
+        let client = if self.proving.blocked_rpc_methods.is_empty() {
+            ClientBuilder::default().http(url)
+        } else {
+            ClientBuilder::default()
+                .layer(BlockedMethodsLayer::new(
+                    self.proving.blocked_rpc_methods.iter().cloned(),
+                ))
+                .http(url)
+        };
+        Ok(client)
+    }
+
     pub async fn create_providers(&self) -> Result<SingleChainProviders, SingleChainHostError> {
+        if !self.proving.blocked_rpc_methods.is_empty() {
+            // Build the providers with the blocked-methods layer on the RPC clients. Mirrors
+            // kona's SingleChainHost::create_providers, which offers no layering hook.
+            let l1_provider = RootProvider::new(
+                self.rpc_client(
+                    self.kona
+                        .l1_node_address
+                        .as_ref()
+                        .ok_or(SingleChainHostError::Other("Provider must be set"))?,
+                )?,
+            );
+            let blob_provider = OnlineBlobProvider::init(OnlineBeaconClient::new_http(
+                self.kona
+                    .l1_beacon_address
+                    .clone()
+                    .ok_or(SingleChainHostError::Other("Beacon API URL must be set"))?,
+            ))
+            .await;
+            let l2_provider = RootProvider::<Optimism>::new(
+                self.rpc_client(
+                    self.kona
+                        .l2_node_address
+                        .as_ref()
+                        .ok_or(SingleChainHostError::Other("L2 node address must be set"))?,
+                )?,
+            );
+            return Ok(SingleChainProviders {
+                l1: l1_provider,
+                blobs: blob_provider,
+                l2: l2_provider,
+            });
+        }
         AssertUnwindSafe(self.kona.clone().create_providers())
             .catch_unwind()
             .await

--- a/crates/prover/src/client/payload.rs
+++ b/crates/prover/src/client/payload.rs
@@ -74,12 +74,14 @@ pub async fn run_payload_client(
             {
                 Ok(witness) => break witness,
                 Err(err) => {
-                    // A missing method never recovers by retrying; this also covers the
-                    // method being blocklisted via --blocked-rpc-methods.
+                    // Give up only when the method is intentionally blocked via
+                    // --blocked-rpc-methods: that can never succeed. A generic "method not
+                    // found" may recover on retry across a load-balanced provider pool, so we
+                    // keep retrying as before.
                     let err = anyhow!(err);
-                    if crate::hint_backoff::is_method_unavailable(&err) {
+                    if crate::hint_backoff::is_method_blacklisted(&err) {
                         error!(
-                            "debug_executionWitness unavailable, skipping payload preflight: {err:#}"
+                            "debug_executionWitness blocked, skipping payload preflight: {err:#}"
                         );
                         return Ok(false);
                     }

--- a/crates/prover/src/client/payload.rs
+++ b/crates/prover/src/client/payload.rs
@@ -73,10 +73,21 @@ pub async fn run_payload_client(
                 .await
             {
                 Ok(witness) => break witness,
-                Err(err) => error!(
-                    "Failed to fetch payload for {} (Retry)\n{err:?}.",
-                    boot_info.claimed_l2_block_number + 1,
-                ),
+                Err(err) => {
+                    // A missing method never recovers by retrying; this also covers the
+                    // method being blocklisted via --blocked-rpc-methods.
+                    let err = anyhow!(err);
+                    if crate::hint_backoff::is_method_unavailable(&err) {
+                        error!(
+                            "debug_executionWitness unavailable, skipping payload preflight: {err:#}"
+                        );
+                        return Ok(false);
+                    }
+                    error!(
+                        "Failed to fetch payload for {} (Retry)\n{err:?}.",
+                        boot_info.claimed_l2_block_number + 1,
+                    )
+                }
             };
         };
 

--- a/crates/prover/src/hint_backoff.rs
+++ b/crates/prover/src/hint_backoff.rs
@@ -20,9 +20,10 @@
 //! flood the RPC provider. Sleeping in the error path here paces that loop without requiring
 //! kona changes: the loop cannot start the next attempt until `fetch_hint` returns.
 //!
-//! JSON-RPC "method not found" failures are exempt from the delay. kona retries the retained
-//! high-level hint before every fine-grained fetch and relies on it failing fast on nodes that
-//! do not implement the method, so those failures are part of normal operation.
+//! Errors from a method blocked via `--blocked-rpc-methods` are exempt from the delay: they
+//! can never succeed, so kona should fall through to fine-grained hints without pacing. A
+//! generic "method not found" is not exempt, since behind a load balancer it can recover on
+//! retry (see [is_method_blacklisted]).
 
 use alloy_primitives::{keccak256, B256};
 use anyhow::Result;
@@ -71,15 +72,15 @@ fn backoff_delay(consecutive_failures: u32) -> Duration {
     Duration::from_millis(millis)
 }
 
-/// Returns true for JSON-RPC "method not found" responses (code -32601 and the message
-/// variants used by common execution clients). Retrying these cannot succeed and delaying
-/// them stalls kona's high-level-hint fallthrough, so they must pass through undelayed.
-pub(crate) fn is_method_unavailable(err: &anyhow::Error) -> bool {
-    let text = format!("{err:#}").to_lowercase();
-    text.contains("-32601")
-        || text.contains("method not found")
-        || text.contains("does not exist/is not available")
-        || text.contains("unsupported method")
+/// Returns true for an error from a method blocked locally by `--blocked-rpc-methods`.
+///
+/// A blocked method can never succeed, so callers give up (skip retries and backoff delay)
+/// on it. A generic "method not found" from the provider is deliberately not matched: behind
+/// a load balancer it can be transient and recover on a later attempt, so it stays on the
+/// normal retry path. To fast-path a method a node genuinely lacks, add it to
+/// `--blocked-rpc-methods`.
+pub(crate) fn is_method_blacklisted(err: &anyhow::Error) -> bool {
+    format!("{err:#}").contains(crate::rpc::BLOCKED_METHOD_MARKER)
 }
 
 fn record_failure(map: &mut FailureMap, key: (u64, B256), now: Instant) -> (u32, Duration) {
@@ -130,7 +131,9 @@ where
                 Ok(())
             }
             Err(err) => {
-                if is_method_unavailable(&err) {
+                if is_method_blacklisted(&err) {
+                    // Intentionally blocked; retrying cannot help, so return without delay
+                    // and let kona fall through to fine-grained hints.
                     return Err(err);
                 }
                 let (attempts, delay) = record_failure(
@@ -226,22 +229,22 @@ mod tests {
     }
 
     #[test]
-    fn method_unavailable_detection() {
-        // op-geth wording, as returned by the devnet node for debug_executePayload.
-        assert!(is_method_unavailable(&anyhow!(
-            "server returned an error response: error code -32601: \
-             the method debug_executePayload does not exist/is not available"
-        )));
-        // reth wording.
-        assert!(is_method_unavailable(&anyhow!("Method not found")));
-        // Detection must see through anyhow context chains.
-        assert!(is_method_unavailable(
-            &anyhow!("error code -32601").context("debug_executePayload failed")
+    fn method_blacklisted_detection() {
+        // The middleware marker is classified as blacklisted, through anyhow context chains.
+        let blocked = anyhow!(
+            "error code -32601: the method debug_executePayload is {}",
+            crate::rpc::BLOCKED_METHOD_MARKER
+        );
+        assert!(is_method_blacklisted(&blocked));
+        assert!(is_method_blacklisted(
+            &blocked.context("debug_executePayload failed")
         ));
-        assert!(!is_method_unavailable(&anyhow!(
-            "server returned an error response: error code -32001: block not found"
+        // A generic method-not-found is NOT blacklisted: it may recover across a
+        // load-balanced pool, so retry loops must keep trying.
+        assert!(!is_method_blacklisted(&anyhow!(
+            "error code -32601: the method debug_executePayload does not exist/is not available"
         )));
-        assert!(!is_method_unavailable(&anyhow!("HTTP error 429")));
+        assert!(!is_method_blacklisted(&anyhow!("HTTP error 429")));
     }
 
     #[derive(Clone, PartialEq, Eq, Hash, Debug)]
@@ -278,10 +281,10 @@ mod tests {
         }
     }
 
-    struct MethodUnavailableHandler;
+    struct BlacklistedHandler;
 
     #[async_trait]
-    impl HintHandler for MethodUnavailableHandler {
+    impl HintHandler for BlacklistedHandler {
         type Cfg = TestCfg;
 
         async fn fetch_hint(
@@ -291,7 +294,8 @@ mod tests {
             _kv: SharedKeyValueStore,
         ) -> Result<()> {
             Err(anyhow!(
-                "error code -32601: the method debug_executePayload does not exist/is not available"
+                "error code -32601: the method debug_executePayload is {}",
+                crate::rpc::BLOCKED_METHOD_MARKER
             ))
         }
     }
@@ -324,12 +328,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn method_unavailable_passes_through_undelayed() {
-        let data: &[u8] = b"method_unavailable_passes_through_undelayed";
+    async fn blacklisted_method_passes_through_undelayed() {
+        let data: &[u8] = b"blacklisted_method_passes_through_undelayed";
         let key = hint_key(&TestHint, data);
 
         let started = Instant::now();
-        BackoffWrapper::<MethodUnavailableHandler, TestCfg>::fetch_hint(
+        BackoffWrapper::<BlacklistedHandler, TestCfg>::fetch_hint(
             test_hint(data),
             &TestCfg,
             &(),

--- a/crates/prover/src/hint_backoff.rs
+++ b/crates/prover/src/hint_backoff.rs
@@ -74,7 +74,7 @@ fn backoff_delay(consecutive_failures: u32) -> Duration {
 /// Returns true for JSON-RPC "method not found" responses (code -32601 and the message
 /// variants used by common execution clients). Retrying these cannot succeed and delaying
 /// them stalls kona's high-level-hint fallthrough, so they must pass through undelayed.
-fn is_method_unavailable(err: &anyhow::Error) -> bool {
+pub(crate) fn is_method_unavailable(err: &anyhow::Error) -> bool {
     let text = format!("{err:#}").to_lowercase();
     text.contains("-32601")
         || text.contains("method not found")

--- a/crates/prover/src/hint_handler.rs
+++ b/crates/prover/src/hint_handler.rs
@@ -32,29 +32,7 @@ use kona_proof::l1::ROOTS_OF_UNITY;
 use kona_proof::{Hint, HintType};
 use reqwest::Client;
 use std::marker::PhantomData;
-use std::sync::OnceLock;
 use tracing::warn;
-
-/// Returns true when serving L2 payload witness hints via `debug_executePayload` is
-/// disabled through the KAILUA_DISABLE_EXECUTE_PAYLOAD environment variable.
-///
-/// Unlike the `debug_executionWitness` prefetch (one cached call per block, unaffected by
-/// this flag), the `debug_executePayload` hint fallback is uncached: the backend retries
-/// the retained hint on every preimage fetch, so a provider can be asked to re-execute the
-/// same payload repeatedly. Earlier releases disabled this path outright after a successful
-/// witness prefetch for exactly that reason. With the flag set, payload witness hints that
-/// miss the prefetched store fall through to fine-grained hints instead of reaching the RPC.
-/// Read once and cached for the process lifetime.
-pub fn execute_payload_disabled() -> bool {
-    static DISABLED: OnceLock<bool> = OnceLock::new();
-    *DISABLED.get_or_init(|| is_truthy(std::env::var("KAILUA_DISABLE_EXECUTE_PAYLOAD").ok()))
-}
-
-fn is_truthy(value: Option<String>) -> bool {
-    value
-        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
-        .unwrap_or(false)
-}
 
 #[derive(Debug, Clone, Copy)]
 struct ParsedBlobHint {
@@ -97,10 +75,6 @@ pub trait BlobFallbackAdapter: OnlineHostBackendCfg {
     /// Returns true when the outer hint type represents a standard L1 blob hint.
     fn is_l1_blob_hint(ty: &Self::HintType) -> bool;
 
-    /// Returns true when the outer hint type requests an L2 payload witness, which the
-    /// inner handler serves via `debug_executePayload`.
-    fn is_l2_payload_witness_hint(ty: &Self::HintType) -> bool;
-
     /// Returns the underlying single-chain config used for beacon blob fetching.
     fn single_chain_cfg(cfg: &Self) -> &SingleChainHost;
 
@@ -134,15 +108,6 @@ where
         providers: &<Self::Cfg as OnlineHostBackendCfg>::Providers,
         kv: SharedKeyValueStore,
     ) -> Result<()> {
-        if Cfg::is_l2_payload_witness_hint(&hint.ty) && execute_payload_disabled() {
-            // Mimic an unsupported-method response without contacting the RPC: kona's
-            // backend falls through to fine-grained hints, and the retry pacing wrapper
-            // recognizes the message as method-unavailable and applies no delay.
-            return Err(anyhow!(
-                "execute payload disabled: the method debug_executePayload does not exist/is not available"
-            ));
-        }
-
         if !Cfg::is_l1_blob_hint(&hint.ty) {
             return Inner::fetch_hint(hint, cfg, providers, kv).await;
         }
@@ -176,10 +141,6 @@ impl BlobFallbackAdapter for SingleChainHost {
         *ty == HintType::L1Blob
     }
 
-    fn is_l2_payload_witness_hint(ty: &Self::HintType) -> bool {
-        *ty == HintType::L2PayloadWitness
-    }
-
     fn single_chain_cfg(cfg: &Self) -> &SingleChainHost {
         cfg
     }
@@ -198,13 +159,6 @@ impl BlobFallbackAdapter for hokulea_host_bin::cfg::SingleChainHostWithEigenDA {
         )
     }
 
-    fn is_l2_payload_witness_hint(ty: &Self::HintType) -> bool {
-        matches!(
-            ty,
-            hokulea_proof::hint::ExtendedHintType::Original(HintType::L2PayloadWitness)
-        )
-    }
-
     fn single_chain_cfg(cfg: &Self) -> &SingleChainHost {
         &cfg.kona_cfg
     }
@@ -220,13 +174,6 @@ impl BlobFallbackAdapter for hana_host::celestia::CelestiaChainHost {
         matches!(
             ty,
             hana_oracle::hint::HintWrapper::Standard(HintType::L1Blob)
-        )
-    }
-
-    fn is_l2_payload_witness_hint(ty: &Self::HintType) -> bool {
-        matches!(
-            ty,
-            hana_oracle::hint::HintWrapper::Standard(HintType::L2PayloadWitness)
         )
     }
 
@@ -418,42 +365,6 @@ mod tests {
         sidecar.index = index;
         let hash = B256::from(sidecar.to_kzg_versioned_hash());
         (sidecar, hash)
-    }
-
-    #[test]
-    fn execute_payload_flag_parsing() {
-        assert!(is_truthy(Some("1".into())));
-        assert!(is_truthy(Some("true".into())));
-        assert!(is_truthy(Some(" TRUE ".into())));
-        assert!(is_truthy(Some("yes".into())));
-        assert!(!is_truthy(Some("0".into())));
-        assert!(!is_truthy(Some("false".into())));
-        assert!(!is_truthy(Some("".into())));
-        assert!(!is_truthy(None));
-    }
-
-    #[test]
-    fn payload_witness_hint_detection() {
-        assert!(SingleChainHost::is_l2_payload_witness_hint(
-            &HintType::L2PayloadWitness
-        ));
-        assert!(!SingleChainHost::is_l2_payload_witness_hint(
-            &HintType::L1Blob
-        ));
-        assert!(!SingleChainHost::is_l1_blob_hint(
-            &HintType::L2PayloadWitness
-        ));
-    }
-
-    #[test]
-    fn suppression_error_is_exempt_from_retry_delay() {
-        // The synthesized error must be classified as method-unavailable so the
-        // backoff wrapper passes it through without sleeping; kona then falls
-        // through to fine-grained hints at full speed.
-        let err = anyhow!(
-            "execute payload disabled: the method debug_executePayload does not exist/is not available"
-        );
-        assert!(crate::hint_backoff::is_method_unavailable(&err));
     }
 
     #[test]

--- a/crates/prover/src/hint_handler.rs
+++ b/crates/prover/src/hint_handler.rs
@@ -32,7 +32,25 @@ use kona_proof::l1::ROOTS_OF_UNITY;
 use kona_proof::{Hint, HintType};
 use reqwest::Client;
 use std::marker::PhantomData;
+use std::sync::OnceLock;
 use tracing::warn;
+
+/// Returns true when payload witness fetching is disabled via the
+/// KAILUA_DISABLE_PAYLOAD_WITNESS environment variable. Both server-side witness paths
+/// (`debug_executionWitness` prefetch and `debug_executePayload` hint fallback) are heavy
+/// calls that can degrade RPC provider backends; disabling them makes the client derive
+/// through fine-grained hints instead, the same path used when a node does not implement
+/// the methods. Read once and cached for the process lifetime.
+pub fn payload_witness_disabled() -> bool {
+    static DISABLED: OnceLock<bool> = OnceLock::new();
+    *DISABLED.get_or_init(|| is_truthy(std::env::var("KAILUA_DISABLE_PAYLOAD_WITNESS").ok()))
+}
+
+fn is_truthy(value: Option<String>) -> bool {
+    value
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false)
+}
 
 #[derive(Debug, Clone, Copy)]
 struct ParsedBlobHint {
@@ -75,6 +93,10 @@ pub trait BlobFallbackAdapter: OnlineHostBackendCfg {
     /// Returns true when the outer hint type represents a standard L1 blob hint.
     fn is_l1_blob_hint(ty: &Self::HintType) -> bool;
 
+    /// Returns true when the outer hint type requests an L2 payload witness, which the
+    /// inner handler serves via `debug_executePayload`.
+    fn is_l2_payload_witness_hint(ty: &Self::HintType) -> bool;
+
     /// Returns the underlying single-chain config used for beacon blob fetching.
     fn single_chain_cfg(cfg: &Self) -> &SingleChainHost;
 
@@ -108,6 +130,15 @@ where
         providers: &<Self::Cfg as OnlineHostBackendCfg>::Providers,
         kv: SharedKeyValueStore,
     ) -> Result<()> {
+        if Cfg::is_l2_payload_witness_hint(&hint.ty) && payload_witness_disabled() {
+            // Mimic an unsupported-method response without contacting the RPC: kona's
+            // backend falls through to fine-grained hints, and the retry pacing wrapper
+            // recognizes the message as method-unavailable and applies no delay.
+            return Err(anyhow!(
+                "payload witness disabled: the method debug_executePayload does not exist/is not available"
+            ));
+        }
+
         if !Cfg::is_l1_blob_hint(&hint.ty) {
             return Inner::fetch_hint(hint, cfg, providers, kv).await;
         }
@@ -141,6 +172,10 @@ impl BlobFallbackAdapter for SingleChainHost {
         *ty == HintType::L1Blob
     }
 
+    fn is_l2_payload_witness_hint(ty: &Self::HintType) -> bool {
+        *ty == HintType::L2PayloadWitness
+    }
+
     fn single_chain_cfg(cfg: &Self) -> &SingleChainHost {
         cfg
     }
@@ -159,6 +194,13 @@ impl BlobFallbackAdapter for hokulea_host_bin::cfg::SingleChainHostWithEigenDA {
         )
     }
 
+    fn is_l2_payload_witness_hint(ty: &Self::HintType) -> bool {
+        matches!(
+            ty,
+            hokulea_proof::hint::ExtendedHintType::Original(HintType::L2PayloadWitness)
+        )
+    }
+
     fn single_chain_cfg(cfg: &Self) -> &SingleChainHost {
         &cfg.kona_cfg
     }
@@ -174,6 +216,13 @@ impl BlobFallbackAdapter for hana_host::celestia::CelestiaChainHost {
         matches!(
             ty,
             hana_oracle::hint::HintWrapper::Standard(HintType::L1Blob)
+        )
+    }
+
+    fn is_l2_payload_witness_hint(ty: &Self::HintType) -> bool {
+        matches!(
+            ty,
+            hana_oracle::hint::HintWrapper::Standard(HintType::L2PayloadWitness)
         )
     }
 
@@ -365,6 +414,42 @@ mod tests {
         sidecar.index = index;
         let hash = B256::from(sidecar.to_kzg_versioned_hash());
         (sidecar, hash)
+    }
+
+    #[test]
+    fn payload_witness_flag_parsing() {
+        assert!(is_truthy(Some("1".into())));
+        assert!(is_truthy(Some("true".into())));
+        assert!(is_truthy(Some(" TRUE ".into())));
+        assert!(is_truthy(Some("yes".into())));
+        assert!(!is_truthy(Some("0".into())));
+        assert!(!is_truthy(Some("false".into())));
+        assert!(!is_truthy(Some("".into())));
+        assert!(!is_truthy(None));
+    }
+
+    #[test]
+    fn payload_witness_hint_detection() {
+        assert!(SingleChainHost::is_l2_payload_witness_hint(
+            &HintType::L2PayloadWitness
+        ));
+        assert!(!SingleChainHost::is_l2_payload_witness_hint(
+            &HintType::L1Blob
+        ));
+        assert!(!SingleChainHost::is_l1_blob_hint(
+            &HintType::L2PayloadWitness
+        ));
+    }
+
+    #[test]
+    fn suppression_error_is_exempt_from_retry_delay() {
+        // The synthesized error must be classified as method-unavailable so the
+        // backoff wrapper passes it through without sleeping; kona then falls
+        // through to fine-grained hints at full speed.
+        let err = anyhow!(
+            "payload witness disabled: the method debug_executePayload does not exist/is not available"
+        );
+        assert!(crate::hint_backoff::is_method_unavailable(&err));
     }
 
     #[test]

--- a/crates/prover/src/hint_handler.rs
+++ b/crates/prover/src/hint_handler.rs
@@ -35,15 +35,19 @@ use std::marker::PhantomData;
 use std::sync::OnceLock;
 use tracing::warn;
 
-/// Returns true when payload witness fetching is disabled via the
-/// KAILUA_DISABLE_PAYLOAD_WITNESS environment variable. Both server-side witness paths
-/// (`debug_executionWitness` prefetch and `debug_executePayload` hint fallback) are heavy
-/// calls that can degrade RPC provider backends; disabling them makes the client derive
-/// through fine-grained hints instead, the same path used when a node does not implement
-/// the methods. Read once and cached for the process lifetime.
-pub fn payload_witness_disabled() -> bool {
+/// Returns true when serving L2 payload witness hints via `debug_executePayload` is
+/// disabled through the KAILUA_DISABLE_EXECUTE_PAYLOAD environment variable.
+///
+/// Unlike the `debug_executionWitness` prefetch (one cached call per block, unaffected by
+/// this flag), the `debug_executePayload` hint fallback is uncached: the backend retries
+/// the retained hint on every preimage fetch, so a provider can be asked to re-execute the
+/// same payload repeatedly. Earlier releases disabled this path outright after a successful
+/// witness prefetch for exactly that reason. With the flag set, payload witness hints that
+/// miss the prefetched store fall through to fine-grained hints instead of reaching the RPC.
+/// Read once and cached for the process lifetime.
+pub fn execute_payload_disabled() -> bool {
     static DISABLED: OnceLock<bool> = OnceLock::new();
-    *DISABLED.get_or_init(|| is_truthy(std::env::var("KAILUA_DISABLE_PAYLOAD_WITNESS").ok()))
+    *DISABLED.get_or_init(|| is_truthy(std::env::var("KAILUA_DISABLE_EXECUTE_PAYLOAD").ok()))
 }
 
 fn is_truthy(value: Option<String>) -> bool {
@@ -130,12 +134,12 @@ where
         providers: &<Self::Cfg as OnlineHostBackendCfg>::Providers,
         kv: SharedKeyValueStore,
     ) -> Result<()> {
-        if Cfg::is_l2_payload_witness_hint(&hint.ty) && payload_witness_disabled() {
+        if Cfg::is_l2_payload_witness_hint(&hint.ty) && execute_payload_disabled() {
             // Mimic an unsupported-method response without contacting the RPC: kona's
             // backend falls through to fine-grained hints, and the retry pacing wrapper
             // recognizes the message as method-unavailable and applies no delay.
             return Err(anyhow!(
-                "payload witness disabled: the method debug_executePayload does not exist/is not available"
+                "execute payload disabled: the method debug_executePayload does not exist/is not available"
             ));
         }
 
@@ -417,7 +421,7 @@ mod tests {
     }
 
     #[test]
-    fn payload_witness_flag_parsing() {
+    fn execute_payload_flag_parsing() {
         assert!(is_truthy(Some("1".into())));
         assert!(is_truthy(Some("true".into())));
         assert!(is_truthy(Some(" TRUE ".into())));
@@ -447,7 +451,7 @@ mod tests {
         // backoff wrapper passes it through without sleeping; kona then falls
         // through to fine-grained hints at full speed.
         let err = anyhow!(
-            "payload witness disabled: the method debug_executePayload does not exist/is not available"
+            "execute payload disabled: the method debug_executePayload does not exist/is not available"
         );
         assert!(crate::hint_backoff::is_method_unavailable(&err));
     }

--- a/crates/prover/src/lib.rs
+++ b/crates/prover/src/lib.rs
@@ -39,6 +39,7 @@ pub mod profiling;
 pub mod proof;
 pub mod prove;
 pub mod risczero;
+pub mod rpc;
 pub mod tasks;
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/prover/src/rpc.rs
+++ b/crates/prover/src/rpc.rs
@@ -1,0 +1,288 @@
+// Copyright 2026 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Transport layer that answers blocklisted RPC methods locally instead of sending them.
+//!
+//! Blocked methods receive a standard JSON-RPC "method not found" error (-32601), the same
+//! response a node that does not implement the method would return. Callers with an existing
+//! unsupported-method fallback (such as kona's payload witness hint falling through to
+//! fine-grained hints) then take that path without the request ever reaching the provider.
+//! The error message matches [crate::hint_backoff::is_method_unavailable], so the retry
+//! pacing wrapper applies no delay to these responses.
+
+use alloy::rpc::json_rpc::{
+    ErrorPayload, RequestPacket, Response, ResponsePacket, ResponsePayload,
+};
+use alloy::transports::{TransportError, TransportFut};
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+
+/// JSON-RPC error code for a method that does not exist.
+const METHOD_NOT_FOUND: i64 = -32601;
+
+/// Tower layer that installs [BlockedMethodsService] over a transport.
+#[derive(Clone, Debug)]
+pub struct BlockedMethodsLayer {
+    blocked: Arc<HashSet<String>>,
+}
+
+impl BlockedMethodsLayer {
+    pub fn new(methods: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            blocked: Arc::new(methods.into_iter().collect()),
+        }
+    }
+}
+
+impl<S> Layer<S> for BlockedMethodsLayer {
+    type Service = BlockedMethodsService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        BlockedMethodsService {
+            inner,
+            blocked: self.blocked.clone(),
+        }
+    }
+}
+
+/// Transport service that responds to blocklisted methods locally with a -32601 error.
+#[derive(Clone, Debug)]
+pub struct BlockedMethodsService<S> {
+    inner: S,
+    blocked: Arc<HashSet<String>>,
+}
+
+fn method_not_found(request: &alloy::rpc::json_rpc::SerializedRequest) -> Response {
+    Response {
+        id: request.id().clone(),
+        payload: ResponsePayload::Failure(ErrorPayload {
+            code: METHOD_NOT_FOUND,
+            message: format!(
+                "the method {} does not exist/is not available",
+                request.method()
+            )
+            .into(),
+            data: None,
+        }),
+    }
+}
+
+impl<S> Service<RequestPacket> for BlockedMethodsService<S>
+where
+    S: Service<RequestPacket, Response = ResponsePacket, Error = TransportError>
+        + Send
+        + Sync
+        + Clone
+        + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = ResponsePacket;
+    type Error = TransportError;
+    type Future = TransportFut<'static>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: RequestPacket) -> Self::Future {
+        match request {
+            RequestPacket::Single(req) if self.blocked.contains(req.method()) => {
+                let response = method_not_found(&req);
+                Box::pin(async move { Ok(ResponsePacket::Single(response)) })
+            }
+            RequestPacket::Batch(requests) => {
+                let (blocked, allowed): (Vec<_>, Vec<_>) = requests
+                    .into_iter()
+                    .partition(|req| self.blocked.contains(req.method()));
+                if blocked.is_empty() {
+                    // Nothing to block; forward the whole batch untouched.
+                    return Box::pin(self.inner.call(RequestPacket::Batch(allowed)));
+                }
+                let mut local: Vec<Response> = blocked.iter().map(method_not_found).collect();
+                if allowed.is_empty() {
+                    return Box::pin(async move { Ok(ResponsePacket::Batch(local)) });
+                }
+                // Forward the allowed subset and merge in the locally answered entries.
+                // JSON-RPC batch responses are matched by id, so ordering is not significant.
+                let fut = self.inner.call(RequestPacket::Batch(allowed));
+                Box::pin(async move {
+                    let mut responses = match fut.await? {
+                        ResponsePacket::Batch(responses) => responses,
+                        ResponsePacket::Single(response) => vec![response],
+                    };
+                    responses.append(&mut local);
+                    Ok(ResponsePacket::Batch(responses))
+                })
+            }
+            other => Box::pin(self.inner.call(other)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::rpc::json_rpc::{Id, Request, SerializedRequest};
+    use serde_json::value::RawValue;
+    use std::sync::Mutex;
+
+    fn request(method: &'static str, id: u64) -> SerializedRequest {
+        Request::<()>::new(method, Id::Number(id), ())
+            .serialize()
+            .unwrap()
+    }
+
+    /// Inner transport that records calls and answers every request with a success.
+    #[derive(Clone, Default)]
+    struct MockTransport {
+        calls: Arc<Mutex<Vec<RequestPacket>>>,
+    }
+
+    impl Service<RequestPacket> for MockTransport {
+        type Response = ResponsePacket;
+        type Error = TransportError;
+        type Future = TransportFut<'static>;
+
+        fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, request: RequestPacket) -> Self::Future {
+            self.calls.lock().unwrap().push(request.clone());
+            let responses: Vec<Response> = request
+                .requests()
+                .iter()
+                .map(|req| Response {
+                    id: req.id().clone(),
+                    payload: ResponsePayload::Success(
+                        RawValue::from_string("\"0x1\"".into()).unwrap().into(),
+                    ),
+                })
+                .collect();
+            let packet = match request {
+                RequestPacket::Single(_) => {
+                    ResponsePacket::Single(responses.into_iter().next().unwrap())
+                }
+                RequestPacket::Batch(_) => ResponsePacket::Batch(responses),
+            };
+            Box::pin(async move { Ok(packet) })
+        }
+    }
+
+    fn service(blocked: &[&str]) -> (BlockedMethodsService<MockTransport>, MockTransport) {
+        let mock = MockTransport::default();
+        let layer = BlockedMethodsLayer::new(blocked.iter().map(|m| m.to_string()));
+        (layer.layer(mock.clone()), mock)
+    }
+
+    #[tokio::test]
+    async fn blocked_single_is_answered_locally() {
+        let (mut svc, mock) = service(&["debug_executePayload"]);
+        let resp = svc
+            .call(RequestPacket::Single(request("debug_executePayload", 1)))
+            .await
+            .unwrap();
+        let ResponsePacket::Single(resp) = resp else {
+            panic!("expected single response")
+        };
+        let ResponsePayload::Failure(err) = resp.payload else {
+            panic!("expected failure payload")
+        };
+        assert_eq!(err.code, -32601);
+        assert!(err.message.contains("does not exist/is not available"));
+        assert!(
+            mock.calls.lock().unwrap().is_empty(),
+            "inner must not be called"
+        );
+    }
+
+    #[tokio::test]
+    async fn allowed_single_passes_through() {
+        let (mut svc, mock) = service(&["debug_executePayload"]);
+        let resp = svc
+            .call(RequestPacket::Single(request("eth_blockNumber", 2)))
+            .await
+            .unwrap();
+        assert!(matches!(
+            resp,
+            ResponsePacket::Single(Response {
+                payload: ResponsePayload::Success(_),
+                ..
+            })
+        ));
+        assert_eq!(mock.calls.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn mixed_batch_blocks_per_entry() {
+        let (mut svc, mock) = service(&["debug_executePayload"]);
+        let resp = svc
+            .call(RequestPacket::Batch(vec![
+                request("eth_blockNumber", 1),
+                request("debug_executePayload", 2),
+                request("eth_chainId", 3),
+            ]))
+            .await
+            .unwrap();
+        let ResponsePacket::Batch(responses) = resp else {
+            panic!("expected batch response")
+        };
+        assert_eq!(responses.len(), 3);
+        let blocked: Vec<_> = responses
+            .iter()
+            .filter(|r| matches!(r.payload, ResponsePayload::Failure(_)))
+            .collect();
+        assert_eq!(blocked.len(), 1);
+        assert_eq!(blocked[0].id, Id::Number(2));
+        // Only the allowed subset reached the inner transport.
+        let calls = mock.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].requests().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn fully_blocked_batch_never_reaches_inner() {
+        let (mut svc, mock) = service(&["debug_executePayload", "debug_executionWitness"]);
+        let resp = svc
+            .call(RequestPacket::Batch(vec![
+                request("debug_executePayload", 1),
+                request("debug_executionWitness", 2),
+            ]))
+            .await
+            .unwrap();
+        let ResponsePacket::Batch(responses) = resp else {
+            panic!("expected batch response")
+        };
+        assert_eq!(responses.len(), 2);
+        assert!(mock.calls.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn local_error_is_exempt_from_retry_delay() {
+        // The synthesized message must be classified as method-unavailable so the retry
+        // pacing wrapper passes it through without sleeping.
+        let response = method_not_found(&request("debug_executePayload", 1));
+        let ResponsePayload::Failure(err) = response.payload else {
+            panic!("expected failure payload")
+        };
+        let err = anyhow::anyhow!(
+            "server returned an error response: error code {}: {}",
+            err.code,
+            err.message
+        );
+        assert!(crate::hint_backoff::is_method_unavailable(&err));
+    }
+}

--- a/crates/prover/src/rpc.rs
+++ b/crates/prover/src/rpc.rs
@@ -14,12 +14,12 @@
 
 //! Transport layer that answers blocklisted RPC methods locally instead of sending them.
 //!
-//! Blocked methods receive a standard JSON-RPC "method not found" error (-32601), the same
-//! response a node that does not implement the method would return. Callers with an existing
-//! unsupported-method fallback (such as kona's payload witness hint falling through to
-//! fine-grained hints) then take that path without the request ever reaching the provider.
-//! The error message matches [crate::hint_backoff::is_method_unavailable], so the retry
-//! pacing wrapper applies no delay to these responses.
+//! Blocked methods receive a JSON-RPC "method not found" error (-32601) carrying
+//! [BLOCKED_METHOD_MARKER], without the request ever reaching the provider. Callers with an
+//! existing unsupported-method fallback (such as kona's payload witness hint falling through
+//! to fine-grained hints) then take that path. The marker lets retry loops distinguish an
+//! intentional, permanent block (give up, via [crate::hint_backoff::is_method_blacklisted])
+//! from a generic "method not found" that might recover across a load-balanced pool (retry).
 
 use alloy::rpc::json_rpc::{
     ErrorPayload, RequestPacket, Response, ResponsePacket, ResponsePayload,
@@ -32,6 +32,12 @@ use tower::{Layer, Service};
 
 /// JSON-RPC error code for a method that does not exist.
 const METHOD_NOT_FOUND: i64 = -32601;
+
+/// Substring embedded in the error message for a blocklisted method. Unlike a generic
+/// "method not found" (which can vary across a load-balanced provider pool and may recover
+/// on retry), this marks an intentional, permanent local block, so callers key on it to
+/// stop retrying. See [crate::hint_backoff::is_method_blacklisted].
+pub(crate) const BLOCKED_METHOD_MARKER: &str = "blocked by --blocked-rpc-methods";
 
 /// Tower layer that installs [BlockedMethodsService] over a transport.
 #[derive(Clone, Debug)]
@@ -65,16 +71,12 @@ pub struct BlockedMethodsService<S> {
     blocked: Arc<HashSet<String>>,
 }
 
-fn method_not_found(request: &alloy::rpc::json_rpc::SerializedRequest) -> Response {
+fn blocked_response(request: &alloy::rpc::json_rpc::SerializedRequest) -> Response {
     Response {
         id: request.id().clone(),
         payload: ResponsePayload::Failure(ErrorPayload {
             code: METHOD_NOT_FOUND,
-            message: format!(
-                "the method {} does not exist/is not available",
-                request.method()
-            )
-            .into(),
+            message: format!("the method {} is {BLOCKED_METHOD_MARKER}", request.method()).into(),
             data: None,
         }),
     }
@@ -100,7 +102,7 @@ where
     fn call(&mut self, request: RequestPacket) -> Self::Future {
         match request {
             RequestPacket::Single(req) if self.blocked.contains(req.method()) => {
-                let response = method_not_found(&req);
+                let response = blocked_response(&req);
                 Box::pin(async move { Ok(ResponsePacket::Single(response)) })
             }
             RequestPacket::Batch(requests) => {
@@ -111,7 +113,7 @@ where
                     // Nothing to block; forward the whole batch untouched.
                     return Box::pin(self.inner.call(RequestPacket::Batch(allowed)));
                 }
-                let mut local: Vec<Response> = blocked.iter().map(method_not_found).collect();
+                let mut local: Vec<Response> = blocked.iter().map(blocked_response).collect();
                 if allowed.is_empty() {
                     return Box::pin(async move { Ok(ResponsePacket::Batch(local)) });
                 }
@@ -135,6 +137,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy::rpc::client::ClientBuilder;
     use alloy::rpc::json_rpc::{Id, Request, SerializedRequest};
     use serde_json::value::RawValue;
     use std::sync::Mutex;
@@ -168,7 +171,7 @@ mod tests {
                 .map(|req| Response {
                     id: req.id().clone(),
                     payload: ResponsePayload::Success(
-                        RawValue::from_string("\"0x1\"".into()).unwrap().into(),
+                        RawValue::from_string("\"0x1\"".into()).unwrap(),
                     ),
                 })
                 .collect();
@@ -202,7 +205,7 @@ mod tests {
             panic!("expected failure payload")
         };
         assert_eq!(err.code, -32601);
-        assert!(err.message.contains("does not exist/is not available"));
+        assert!(err.message.contains(BLOCKED_METHOD_MARKER));
         assert!(
             mock.calls.lock().unwrap().is_empty(),
             "inner must not be called"
@@ -270,19 +273,22 @@ mod tests {
         assert!(mock.calls.lock().unwrap().is_empty());
     }
 
-    #[test]
-    fn local_error_is_exempt_from_retry_delay() {
-        // The synthesized message must be classified as method-unavailable so the retry
-        // pacing wrapper passes it through without sleeping.
-        let response = method_not_found(&request("debug_executePayload", 1));
-        let ResponsePayload::Failure(err) = response.payload else {
-            panic!("expected failure payload")
-        };
-        let err = anyhow::anyhow!(
-            "server returned an error response: error code {}: {}",
-            err.code,
-            err.message
-        );
-        assert!(crate::hint_backoff::is_method_unavailable(&err));
+    #[tokio::test]
+    async fn blocked_method_through_rpc_client_is_detected() {
+        // Full path: a blocked method routed through a real RpcClient must surface an error
+        // that is_method_blacklisted recognizes. The transport points at an unreachable port,
+        // so a passing test also proves the layer short-circuits before dialing.
+        let client = ClientBuilder::default()
+            .layer(BlockedMethodsLayer::new([
+                "debug_executePayload".to_string()
+            ]))
+            .http("http://127.0.0.1:1/".parse().unwrap());
+        let err = client
+            .request::<_, serde_json::Value>("debug_executePayload", (1u64,))
+            .await
+            .expect_err("blocked method must error");
+        assert!(crate::hint_backoff::is_method_blacklisted(
+            &anyhow::anyhow!(err)
+        ));
     }
 }

--- a/crates/prover/src/tasks.rs
+++ b/crates/prover/src/tasks.rs
@@ -1159,10 +1159,7 @@ pub async fn compute_cached_proof(
         }
 
         // preflight
-        if !args.kona.is_offline()
-            && args.op_node_address.is_some()
-            && !crate::hint_handler::payload_witness_disabled()
-        {
+        if !args.kona.is_offline() && args.op_node_address.is_some() {
             let l2_provider = args
                 .kona
                 .l2_node_address

--- a/crates/prover/src/tasks.rs
+++ b/crates/prover/src/tasks.rs
@@ -1159,30 +1159,25 @@ pub async fn compute_cached_proof(
         }
 
         // preflight
-        if !args.kona.is_offline() && args.op_node_address.is_some() {
-            let l2_provider = args
-                .kona
-                .l2_node_address
-                .as_ref()
-                .map(|addr| {
-                    RootProvider::new_http(
-                        addr.as_str()
-                            .try_into()
-                            .expect("Failed to parse l2_node_address"),
-                    )
-                })
-                .unwrap();
-            let op_node_provider = args
-                .op_node_address
-                .as_ref()
-                .map(|addr| {
-                    OpNodeProvider(RootProvider::new_http(
-                        addr.as_str()
-                            .try_into()
-                            .expect("Failed to parse op_node_address"),
-                    ))
-                })
-                .unwrap();
+        if let Some(op_node_address) = args
+            .op_node_address
+            .as_ref()
+            .filter(|_| !args.kona.is_offline())
+        {
+            // Route through ProveArgs::rpc_client so --blocked-rpc-methods applies here too.
+            let l2_provider = RootProvider::new(
+                args.rpc_client(
+                    args.kona
+                        .l2_node_address
+                        .as_ref()
+                        .expect("l2_node_address is required"),
+                )
+                .expect("Failed to parse l2_node_address"),
+            );
+            let op_node_provider = OpNodeProvider(RootProvider::new(
+                args.rpc_client(op_node_address)
+                    .expect("Failed to parse op_node_address"),
+            ));
             crate::client::payload::run_payload_client(
                 boot.clone(),
                 l2_provider,

--- a/crates/prover/src/tasks.rs
+++ b/crates/prover/src/tasks.rs
@@ -1159,7 +1159,10 @@ pub async fn compute_cached_proof(
         }
 
         // preflight
-        if !args.kona.is_offline() && args.op_node_address.is_some() {
+        if !args.kona.is_offline()
+            && args.op_node_address.is_some()
+            && !crate::hint_handler::payload_witness_disabled()
+        {
             let l2_provider = args
                 .kona
                 .l2_node_address


### PR DESCRIPTION
  Adds `--blocked-rpc-methods` (env `BLOCKED_RPC_METHODS`, comma-separated) to `ProvingArgs`.
  Requests for listed methods are answered locally by a transport layer with a standard
  JSON-RPC -32601 ("method does not exist/is not available") instead of being sent upstream —
  the same response an unsupporting node would give, so callers take their existing fallback
  paths. Batches are handled per-entry: allowed requests are forwarded, blocked ones answered
  locally, responses merged by id.

  Motivation: kona v1.6.0's retained `L2PayloadWitness` hint reaches the provider as uncached
  `debug_executePayload` (pre-upgrade kailua disabled that path after a successful witness
  prefetch, "as it doesn't have caching"). In production this raised per-task RPC cost enough
  to drop sustainable concurrency from 40–60 tasks to under 10, with provider backends showing
  internal database failures. Setting `BLOCKED_RPC_METHODS=debug_executePayload` restores the
  pre-upgrade behavior; the `debug_executionWitness` prefetch is unaffected (and its retry loop
  now soft-fails instead of spinning if that method is ever blocked or missing).

  The -32601 message matches the retry-pacing wrapper's method-unavailable exemption, so no
  backoff delay applies (test-pinned). Default: empty list, no behavior change.